### PR TITLE
feat: 駒の移動パターン定義を実装 (#3)

### DIFF
--- a/src/lib/shogi/moves.ts
+++ b/src/lib/shogi/moves.ts
@@ -1,4 +1,4 @@
-import type { MoveDirection, MovePattern, Piece, PieceType, Player, PromotedPieceType } from './types'
+import type { MoveDirection, MovePattern, PieceType, Player, PromotedPieceType } from './types'
 
 // ============================================================
 // 方向定数（先手基準）
@@ -8,12 +8,14 @@ import type { MoveDirection, MovePattern, Piece, PieceType, Player, PromotedPiec
 
 const FORWARD: MoveDirection = { dRow: -1, dCol: 0 }
 const BACKWARD: MoveDirection = { dRow: +1, dCol: 0 }
-const LEFT: MoveDirection = { dRow: 0, dCol: -1 }
-const RIGHT: MoveDirection = { dRow: 0, dCol: +1 }
-const FORWARD_LEFT: MoveDirection = { dRow: -1, dCol: -1 }
-const FORWARD_RIGHT: MoveDirection = { dRow: -1, dCol: +1 }
-const BACKWARD_LEFT: MoveDirection = { dRow: +1, dCol: -1 }
-const BACKWARD_RIGHT: MoveDirection = { dRow: +1, dCol: +1 }
+// col=0 が9筋（右端）、col=8 が1筋（左端）なので、
+// 先手から見て右方向 = col減少（dCol: -1）、左方向 = col増加（dCol: +1）
+const RIGHT: MoveDirection = { dRow: 0, dCol: -1 }  // 9筋方向
+const LEFT: MoveDirection = { dRow: 0, dCol: +1 }   // 1筋方向
+const FORWARD_RIGHT: MoveDirection = { dRow: -1, dCol: -1 }
+const FORWARD_LEFT: MoveDirection = { dRow: -1, dCol: +1 }
+const BACKWARD_RIGHT: MoveDirection = { dRow: +1, dCol: -1 }
+const BACKWARD_LEFT: MoveDirection = { dRow: +1, dCol: +1 }
 
 // ============================================================
 // 移動パターン定数
@@ -104,9 +106,9 @@ export const MOVE_PATTERNS: Record<PieceType | PromotedPieceType, MovePattern> =
 // ユーティリティ関数
 // ============================================================
 
-// 駒から移動パターンを取得する
-export function getMovePattern(piece: Piece): MovePattern {
-  return MOVE_PATTERNS[piece.type]
+// 駒種から移動パターンを取得する
+export function getMovePattern(pieceType: PieceType | PromotedPieceType): MovePattern {
+  return MOVE_PATTERNS[pieceType]
 }
 
 // 後手の場合に dRow・dCol を反転して返す


### PR DESCRIPTION
## 概要

Closes #3

全14駒種の移動パターンを `moves.ts` に定義した。

## 変更内容

### `src/lib/shogi/moves.ts`（新規作成）

**定数**
| 定数 | 説明 |
|------|------|
| `MOVE_PATTERNS` | 全14駒種の移動パターン（`Record<PieceType \| PromotedPieceType, MovePattern>`） |

**関数**
| 関数 | 説明 |
|------|------|
| `getMovePattern(piece)` | 駒から移動パターンを取得 |
| `applyPlayerDirection(dir, player)` | 後手の場合に dRow・dCol を反転 |

**駒種別パターン一覧**
| 駒 | steps | slides |
|----|-------|--------|
| 王将 | 全8方向 | なし |
| 金将 | 前・左前・右前・左・右・後（6方向） | なし |
| 銀将 | 前・左前・右前・左後・右後（5方向） | なし |
| 桂馬 | 左桂・右桂（2方向ジャンプ） | なし |
| 歩兵 | 前（1方向） | なし |
| 香車 | なし | 前方向 |
| 飛車 | なし | 前後左右 |
| 角行 | なし | 斜め4方向 |
| 竜王 | 斜め4方向 | 前後左右 |
| 竜馬 | 前後左右 | 斜め4方向 |
| 成銀・成桂・成香・と金 | 金将と同じ | なし |

## 設計決定事項

- 成駒4種（成銀・成桂・成香・と金）は `GOLD_PATTERN` 定数を共有（DRY）
- 方向定数（`FORWARD` 等）をモジュール内定数として定義し、パターン定義の可読性を向上
- `applyPlayerDirection` は先手の場合そのまま返すことでゼロコスト

## テスト計画

- [x] TypeScript コンパイル通過（`npm run build`）
- [x] lint 通過（`npm run lint`）
- [ ] 各パターン・関数のユニットテストは `/shogi-test` スキルを用いて別 Issue で実施予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)