### PR TITLE
feat: 禁手チェック・王手詰み判定・成り判定を実装 (#5)

### DIFF
--- a/src/lib/shogi/rules.ts
+++ b/src/lib/shogi/rules.ts
@@ -1,5 +1,5 @@
 import type { Board, CapturedPieces, Piece, PieceType, Player, Position, PromotedPieceType } from './types'
-import { getPieceAt } from './board'
+import { findKing, getPieceAt, setPieceAt } from './board'
 import { generateMoveCandidates, getLegalDrops, getLegalMoves, isInCheck } from './moves'
 
 // ============================================================
@@ -31,8 +31,7 @@ export function hasNoEscape(
   return false
 }
 
-// 打ち歩詰め判定: 歩を打って相手が詰みになるか（持ち駒打ち含む脱出手を確認）
-// isInCheck で王手確認後に呼ぶこと（王手でない場合は詰みにならないため不要）
+// 打ち歩詰め判定: pos に歩を打った結果、相手が詰みになるか（持ち駒打ち含む脱出手を確認）
 export function isUchifuzume(
   board: Board,
   player: Player,
@@ -40,8 +39,9 @@ export function isUchifuzume(
   capturedPieces: CapturedPieces,
 ): boolean {
   const opponent: Player = player === 'sente' ? 'gote' : 'sente'
-  // 歩を仮に配置した盤面で相手が詰みかどうか
-  return isCheckmate(board, capturedPieces, opponent)
+  // pos に歩を配置した仮盤面で相手が詰みかどうかを判定する
+  const next = setPieceAt(board, pos, { type: 'pawn', owner: player })
+  return isCheckmate(next, capturedPieces, opponent)
 }
 
 // ============================================================
@@ -53,7 +53,7 @@ export { isInCheck }
 
 // 王手をかけている相手駒のリストを返す
 export function getCheckingPieces(board: Board, player: Player): Position[] {
-  const kingPos = findKingPos(board, player)
+  const kingPos = findKing(board, player)
   if (!kingPos) return []
 
   const opponent: Player = player === 'sente' ? 'gote' : 'sente'
@@ -92,17 +92,6 @@ export function isCheckmate(
     if (getLegalDrops(board, player, pt, capturedPieces).length > 0) return false
   }
   return true
-}
-
-// 内部ヘルパー: 王の位置を返す
-function findKingPos(board: Board, player: Player): Position | null {
-  for (let row = 0; row < 9; row++) {
-    for (let col = 0; col < 9; col++) {
-      const piece = board[row][col]
-      if (piece?.type === 'king' && piece.owner === player) return { row, col }
-    }
-  }
-  return null
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要

Closes #5

`rules.ts` を新規作成。設計書セクション7・8に基づき、禁手チェック・王手詰み判定・成り判定を実装した。
Issue #4 で実装済みの関数は再実装せず、案B（新規関数のみ実装）を採用。

## 変更内容

### `src/lib/shogi/rules.ts`（新規作成）

**禁手チェック**
| 関数 | 説明 |
|------|------|
| `isNifu(board, player, col)` | 同筋に未成の歩があるか |
| `hasNoEscape(pieceType, player, pos)` | 行き所のない駒か |
| `isUchifuzume(board, player, pos, capturedPieces)` | 打ち歩詰めか |

**王手・詰み**
| 関数 | 説明 |
|------|------|
| `isInCheck` | `moves.ts` から re-export |
| `getCheckingPieces(board, player)` | 王手をかけている駒のリスト |
| `isCheckmate(board, capturedPieces, player)` | 詰み判定（盤上 + 持ち駒打ち） |

**成り判定**
| 関数 | 説明 |
|------|------|
| `canPromote(piece, from, to)` | 成り可能か |
| `mustPromote(piece, to)` | 強制成りか |
| `getPromotedType(pieceType)` | 成駒変換（成れない駒は null） |
| `getDemotedType(pieceType)` | 元駒変換（持ち駒化用） |

## 設計決定事項（案B）

- `isInCheck` は `moves.ts` で実装済みのため re-export のみ
- `isNifu`/`hasNoEscape` のロジックは単純なため `rules.ts` で独自実装（moves.ts 内部関数に依存しない）
- `isUchifuzume` は `isCheckmate` を活用して実装

## テスト計画

- [x] TypeScript コンパイル通過
- [x] lint 通過
- [ ] ユニットテストは Issue #7 で実施予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)