### PR TITLE
test: コアロジックのユニットテスト実装

### DIFF
--- a/src/lib/shogi/__tests__/board.test.ts
+++ b/src/lib/shogi/__tests__/board.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createInitialBoard,
+  cloneBoard,
+  getPieceAt,
+  setPieceAt,
+  removePieceAt,
+  findKing,
+  addCapturedPiece,
+  consumeCapturedPiece,
+  createInitialCapturedPieces,
+} from '../board'
+
+describe('createInitialBoard', () => {
+  it('row0 col4 は後手の王将', () => {
+    const board = createInitialBoard()
+    const piece = board[0][4]
+    expect(piece).not.toBeNull()
+    expect(piece?.type).toBe('king')
+    expect(piece?.owner).toBe('gote')
+  })
+
+  it('row8 col4 は先手の王将', () => {
+    const board = createInitialBoard()
+    const piece = board[8][4]
+    expect(piece).not.toBeNull()
+    expect(piece?.type).toBe('king')
+    expect(piece?.owner).toBe('sente')
+  })
+
+  it('row6 の全マスが先手の歩兵', () => {
+    const board = createInitialBoard()
+    for (let col = 0; col < 9; col++) {
+      const piece = board[6][col]
+      expect(piece).not.toBeNull()
+      expect(piece?.type).toBe('pawn')
+      expect(piece?.owner).toBe('sente')
+    }
+  })
+
+  it('row2 の全マスが後手の歩兵', () => {
+    const board = createInitialBoard()
+    for (let col = 0; col < 9; col++) {
+      const piece = board[2][col]
+      expect(piece).not.toBeNull()
+      expect(piece?.type).toBe('pawn')
+      expect(piece?.owner).toBe('gote')
+    }
+  })
+
+  it('呼び出しごとに独立したコピーを返す（変更が他方に影響しない）', () => {
+    const board1 = createInitialBoard()
+    const board2 = createInitialBoard()
+    board1[0][0] = null
+    expect(board2[0][0]).not.toBeNull()
+    expect(board2[0][0]?.type).toBe('lance')
+  })
+
+  it('row3〜row5（四〜六段目）はすべて null', () => {
+    const board = createInitialBoard()
+    for (let row = 3; row <= 5; row++) {
+      for (let col = 0; col < 9; col++) {
+        expect(board[row][col]).toBeNull()
+      }
+    }
+  })
+
+  it('後手の飛車は row1 col1 にある', () => {
+    const board = createInitialBoard()
+    const piece = board[1][1]
+    expect(piece?.type).toBe('rook')
+    expect(piece?.owner).toBe('gote')
+  })
+
+  it('先手の角行は row7 col1 にある', () => {
+    const board = createInitialBoard()
+    const piece = board[7][1]
+    expect(piece?.type).toBe('bishop')
+    expect(piece?.owner).toBe('sente')
+  })
+})
+
+describe('cloneBoard', () => {
+  it('クローンは元のボードと同じ内容を持つ', () => {
+    const board = createInitialBoard()
+    const cloned = cloneBoard(board)
+    expect(cloned[0][4]?.type).toBe('king')
+    expect(cloned[0][4]?.owner).toBe('gote')
+  })
+
+  it('クローンへの変更が元に影響しない', () => {
+    const board = createInitialBoard()
+    const cloned = cloneBoard(board)
+    cloned[0][0] = null
+    expect(board[0][0]).not.toBeNull()
+    expect(board[0][0]?.type).toBe('lance')
+  })
+
+  it('元への変更がクローンに影響しない', () => {
+    const board = createInitialBoard()
+    const cloned = cloneBoard(board)
+    board[8][4] = null
+    expect(cloned[8][4]).not.toBeNull()
+    expect(cloned[8][4]?.type).toBe('king')
+  })
+})
+
+describe('getPieceAt', () => {
+  it('存在する駒の情報を返す', () => {
+    const board = createInitialBoard()
+    const piece = getPieceAt(board, { row: 0, col: 4 })
+    expect(piece?.type).toBe('king')
+    expect(piece?.owner).toBe('gote')
+  })
+
+  it('空マスは null を返す', () => {
+    const board = createInitialBoard()
+    const piece = getPieceAt(board, { row: 4, col: 4 })
+    expect(piece).toBeNull()
+  })
+
+  it('盤外（row < 0）は null を返す', () => {
+    const board = createInitialBoard()
+    const piece = getPieceAt(board, { row: -1, col: 0 })
+    expect(piece).toBeNull()
+  })
+
+  it('盤外（col > 8）は null を返す', () => {
+    const board = createInitialBoard()
+    const piece = getPieceAt(board, { row: 0, col: 9 })
+    expect(piece).toBeNull()
+  })
+})
+
+describe('setPieceAt', () => {
+  it('新しい盤面に指定した駒が配置される', () => {
+    const board = createInitialBoard()
+    const newPiece = { type: 'gold' as const, owner: 'sente' as const }
+    const next = setPieceAt(board, { row: 4, col: 4 }, newPiece)
+    expect(next[4][4]?.type).toBe('gold')
+    expect(next[4][4]?.owner).toBe('sente')
+  })
+
+  it('元の盤面は変更されない（イミュータブル）', () => {
+    const board = createInitialBoard()
+    const newPiece = { type: 'gold' as const, owner: 'sente' as const }
+    setPieceAt(board, { row: 4, col: 4 }, newPiece)
+    expect(board[4][4]).toBeNull()
+  })
+})
+
+describe('removePieceAt', () => {
+  it('指定した位置の駒が除去された新しい盤面を返す', () => {
+    const board = createInitialBoard()
+    const next = removePieceAt(board, { row: 0, col: 4 })
+    expect(next[0][4]).toBeNull()
+  })
+
+  it('元の盤面は変更されない（イミュータブル）', () => {
+    const board = createInitialBoard()
+    removePieceAt(board, { row: 0, col: 4 })
+    expect(board[0][4]?.type).toBe('king')
+    expect(board[0][4]?.owner).toBe('gote')
+  })
+})
+
+describe('findKing', () => {
+  it('先手の王の位置を正しく返す', () => {
+    const board = createInitialBoard()
+    const pos = findKing(board, 'sente')
+    expect(pos).toEqual({ row: 8, col: 4 })
+  })
+
+  it('後手の王の位置を正しく返す', () => {
+    const board = createInitialBoard()
+    const pos = findKing(board, 'gote')
+    expect(pos).toEqual({ row: 0, col: 4 })
+  })
+
+  it('王がいない盤面では null を返す', () => {
+    const board = createInitialBoard()
+    // 先手の王を除去
+    board[8][4] = null
+    const pos = findKing(board, 'sente')
+    expect(pos).toBeNull()
+  })
+})
+
+describe('createInitialCapturedPieces', () => {
+  it('先手・後手ともに空のオブジェクトを返す', () => {
+    const captured = createInitialCapturedPieces()
+    expect(captured.sente).toEqual({})
+    expect(captured.gote).toEqual({})
+  })
+})
+
+describe('addCapturedPiece', () => {
+  it('持ち駒に最初の1枚を追加すると count が 1 になる', () => {
+    const captured = createInitialCapturedPieces()
+    const next = addCapturedPiece(captured, 'sente', 'pawn')
+    expect(next.sente.pawn).toBe(1)
+  })
+
+  it('既に持ち駒がある場合は count が加算される', () => {
+    const captured = createInitialCapturedPieces()
+    const after1 = addCapturedPiece(captured, 'sente', 'pawn')
+    const after2 = addCapturedPiece(after1, 'sente', 'pawn')
+    expect(after2.sente.pawn).toBe(2)
+  })
+
+  it('元の持ち駒は変更されない（イミュータブル）', () => {
+    const captured = createInitialCapturedPieces()
+    addCapturedPiece(captured, 'sente', 'pawn')
+    expect(captured.sente.pawn).toBeUndefined()
+  })
+
+  it('後手の持ち駒も正しく追加される', () => {
+    const captured = createInitialCapturedPieces()
+    const next = addCapturedPiece(captured, 'gote', 'rook')
+    expect(next.gote.rook).toBe(1)
+    expect(next.sente.rook).toBeUndefined()
+  })
+})
+
+describe('consumeCapturedPiece', () => {
+  it('count が 2 から 1 に減る', () => {
+    const captured = createInitialCapturedPieces()
+    const added = addCapturedPiece(addCapturedPiece(captured, 'sente', 'pawn'), 'sente', 'pawn')
+    const consumed = consumeCapturedPiece(added, 'sente', 'pawn')
+    expect(consumed.sente.pawn).toBe(1)
+  })
+
+  it('count が 1 のときに消費するとキーが削除される', () => {
+    const captured = createInitialCapturedPieces()
+    const added = addCapturedPiece(captured, 'sente', 'pawn')
+    const consumed = consumeCapturedPiece(added, 'sente', 'pawn')
+    expect(consumed.sente.pawn).toBeUndefined()
+  })
+
+  it('元の持ち駒は変更されない（イミュータブル）', () => {
+    const captured = createInitialCapturedPieces()
+    const added = addCapturedPiece(captured, 'sente', 'pawn')
+    consumeCapturedPiece(added, 'sente', 'pawn')
+    expect(added.sente.pawn).toBe(1)
+  })
+})

--- a/src/lib/shogi/__tests__/game.test.ts
+++ b/src/lib/shogi/__tests__/game.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createInitialGameState,
+  executeMove,
+  executeDrop,
+  undoMove,
+  redoMove,
+} from '../game'
+import {
+  createInitialCapturedPieces,
+  addCapturedPiece,
+  getPieceAt,
+} from '../board'
+import type { GameState } from '../types'
+
+// 空の盤面を作るヘルパー
+function emptyBoard(): Board {
+  return Array.from({ length: 9 }, () => Array(9).fill(null))
+}
+
+// テスト用の最小GameStateを構築するヘルパー
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    ...createInitialGameState(),
+    ...overrides,
+  }
+}
+
+describe('createInitialGameState', () => {
+  it('currentPlayer は sente', () => {
+    const state = createInitialGameState()
+    expect(state.currentPlayer).toBe('sente')
+  })
+
+  it('phase は idle', () => {
+    const state = createInitialGameState()
+    expect(state.phase).toBe('idle')
+  })
+
+  it('legalMoves は空配列', () => {
+    const state = createInitialGameState()
+    expect(state.legalMoves).toHaveLength(0)
+  })
+
+  it('moveHistory.currentIndex は -1', () => {
+    const state = createInitialGameState()
+    expect(state.moveHistory.currentIndex).toBe(-1)
+  })
+
+  it('moveHistory.moves は空配列', () => {
+    const state = createInitialGameState()
+    expect(state.moveHistory.moves).toHaveLength(0)
+  })
+
+  it('isCheck は false', () => {
+    const state = createInitialGameState()
+    expect(state.isCheck).toBe(false)
+  })
+
+  it('winner は null', () => {
+    const state = createInitialGameState()
+    expect(state.winner).toBeNull()
+  })
+})
+
+describe('executeMove: 基本的な移動', () => {
+  it('駒が移動先に正しく配置される', () => {
+    const board = emptyBoard()
+    board[6][4] = { type: 'pawn', owner: 'sente' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const state = makeState({ board })
+    const next = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    expect(getPieceAt(next.board, { row: 5, col: 4 })?.type).toBe('pawn')
+    expect(getPieceAt(next.board, { row: 5, col: 4 })?.owner).toBe('sente')
+  })
+
+  it('移動元のマスが空になる', () => {
+    const board = emptyBoard()
+    board[6][4] = { type: 'pawn', owner: 'sente' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const state = makeState({ board })
+    const next = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    expect(getPieceAt(next.board, { row: 6, col: 4 })).toBeNull()
+  })
+
+  it('currentPlayer が手番交代後に gote に変わる', () => {
+    const state = createInitialGameState()
+    const next = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    expect(next.currentPlayer).toBe('gote')
+  })
+
+  it('moveHistory.currentIndex が 0 に増える', () => {
+    const state = createInitialGameState()
+    const next = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    expect(next.moveHistory.currentIndex).toBe(0)
+  })
+
+  it('moveHistory.moves に1手が追加される', () => {
+    const state = createInitialGameState()
+    const next = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    expect(next.moveHistory.moves).toHaveLength(1)
+  })
+})
+
+describe('executeMove: 駒を取る', () => {
+  it('敵駒を取ると capturedPieces に追加される', () => {
+    const board = emptyBoard()
+    board[5][4] = { type: 'pawn', owner: 'gote' }
+    board[6][4] = { type: 'rook', owner: 'sente' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const state = makeState({ board })
+    const next = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    expect(next.capturedPieces.sente.pawn).toBe(1)
+  })
+
+  it('成駒を取ると元の駒種（demoted）として capturedPieces に入る', () => {
+    const board = emptyBoard()
+    board[5][4] = { type: 'promoted_pawn', owner: 'gote' }
+    board[6][4] = { type: 'rook', owner: 'sente' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const state = makeState({ board })
+    const next = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    // promoted_pawn を取ると pawn として持ち駒に入る
+    expect(next.capturedPieces.sente.pawn).toBe(1)
+    expect(next.capturedPieces.sente.promoted_pawn).toBeUndefined()
+  })
+})
+
+describe('executeMove: 成り', () => {
+  it('promote=true のとき駒が成駒に変わる', () => {
+    const board = emptyBoard()
+    board[3][4] = { type: 'pawn', owner: 'sente' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const state = makeState({ board })
+    const next = executeMove(state, { row: 3, col: 4 }, { row: 2, col: 4 }, true)
+    expect(getPieceAt(next.board, { row: 2, col: 4 })?.type).toBe('promoted_pawn')
+  })
+
+  it('promote=false のとき駒の種類は変わらない', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'silver', owner: 'sente' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const state = makeState({ board })
+    const next = executeMove(state, { row: 4, col: 4 }, { row: 3, col: 4 }, false)
+    expect(getPieceAt(next.board, { row: 3, col: 4 })?.type).toBe('silver')
+  })
+})
+
+describe('executeDrop', () => {
+  it('持ち駒が盤面に配置される', () => {
+    const captured = addCapturedPiece(createInitialCapturedPieces(), 'sente', 'pawn')
+    const board = emptyBoard()
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const state = makeState({ board, capturedPieces: captured })
+    const next = executeDrop(state, 'pawn', { row: 5, col: 4 })
+    expect(getPieceAt(next.board, { row: 5, col: 4 })?.type).toBe('pawn')
+    expect(getPieceAt(next.board, { row: 5, col: 4 })?.owner).toBe('sente')
+  })
+
+  it('持ち駒の枚数が減る', () => {
+    const captured = addCapturedPiece(
+      addCapturedPiece(createInitialCapturedPieces(), 'sente', 'pawn'),
+      'sente',
+      'pawn',
+    )
+    const board = emptyBoard()
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const state = makeState({ board, capturedPieces: captured })
+    const next = executeDrop(state, 'pawn', { row: 5, col: 4 })
+    expect(next.capturedPieces.sente.pawn).toBe(1)
+  })
+
+  it('持ち駒が1枚のときに打つとキーが削除される', () => {
+    const captured = addCapturedPiece(createInitialCapturedPieces(), 'sente', 'pawn')
+    const board = emptyBoard()
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const state = makeState({ board, capturedPieces: captured })
+    const next = executeDrop(state, 'pawn', { row: 5, col: 4 })
+    expect(next.capturedPieces.sente.pawn).toBeUndefined()
+  })
+
+  it('手を打つと currentPlayer が切り替わる', () => {
+    const captured = addCapturedPiece(createInitialCapturedPieces(), 'sente', 'pawn')
+    const board = emptyBoard()
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const state = makeState({ board, capturedPieces: captured })
+    const next = executeDrop(state, 'pawn', { row: 5, col: 4 })
+    expect(next.currentPlayer).toBe('gote')
+  })
+})
+
+describe('undoMove', () => {
+  it('moveHistory.currentIndex が -1 のときは状態を変えない', () => {
+    const state = createInitialGameState()
+    const result = undoMove(state)
+    expect(result).toBe(state)
+  })
+
+  it('undoすると盤面が1手前の状態に戻る', () => {
+    const state = createInitialGameState()
+    const after = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    const undone = undoMove(after)
+    expect(getPieceAt(undone.board, { row: 6, col: 4 })?.type).toBe('pawn')
+    expect(getPieceAt(undone.board, { row: 5, col: 4 })).toBeNull()
+  })
+
+  it('undoすると移動元のマスに駒が戻る', () => {
+    const state = createInitialGameState()
+    const after = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    const undone = undoMove(after)
+    expect(getPieceAt(undone.board, { row: 6, col: 4 })?.owner).toBe('sente')
+  })
+
+  it('undoすると currentPlayer が元に戻る', () => {
+    const state = createInitialGameState()
+    const after = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    const undone = undoMove(after)
+    expect(undone.currentPlayer).toBe('sente')
+  })
+
+  it('undoすると moveHistory.currentIndex が 1 減る', () => {
+    const state = createInitialGameState()
+    const after = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    expect(after.moveHistory.currentIndex).toBe(0)
+    const undone = undoMove(after)
+    expect(undone.moveHistory.currentIndex).toBe(-1)
+  })
+
+  it('取られた駒が盤面に戻り、持ち駒から除去される', () => {
+    const board = emptyBoard()
+    board[5][4] = { type: 'pawn', owner: 'gote' }
+    board[6][4] = { type: 'rook', owner: 'sente' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const state = makeState({ board })
+    const after = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    expect(after.capturedPieces.sente.pawn).toBe(1)
+    const undone = undoMove(after)
+    expect(getPieceAt(undone.board, { row: 5, col: 4 })?.type).toBe('pawn')
+    expect(getPieceAt(undone.board, { row: 5, col: 4 })?.owner).toBe('gote')
+    expect(undone.capturedPieces.sente.pawn).toBeUndefined()
+  })
+})
+
+describe('redoMove', () => {
+  it('redo できる手がない場合は状態を変えない', () => {
+    const state = createInitialGameState()
+    const result = redoMove(state)
+    expect(result).toBe(state)
+  })
+
+  it('undoした手をredoすると元の移動が再実行される', () => {
+    const state = createInitialGameState()
+    const after = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    const undone = undoMove(after)
+    const redone = redoMove(undone)
+    expect(getPieceAt(redone.board, { row: 5, col: 4 })?.type).toBe('pawn')
+    expect(getPieceAt(redone.board, { row: 6, col: 4 })).toBeNull()
+  })
+
+  it('redoすると currentPlayer が再び切り替わる', () => {
+    const state = createInitialGameState()
+    const after = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    const undone = undoMove(after)
+    expect(undone.currentPlayer).toBe('sente')
+    const redone = redoMove(undone)
+    expect(redone.currentPlayer).toBe('gote')
+  })
+})
+
+describe('executeMove after undo: redo履歴がクリアされる', () => {
+  it('undoした後に新しい手を指すとredo履歴が削除される', () => {
+    const state = createInitialGameState()
+    const step1 = executeMove(state, { row: 6, col: 4 }, { row: 5, col: 4 }, false)
+    const step2 = executeMove(step1, { row: 2, col: 4 }, { row: 3, col: 4 }, false)
+    // step1 の状態まで戻す（2手undo）
+    const undone1 = undoMove(step2)
+    const undone2 = undoMove(undone1)
+    expect(undone2.moveHistory.currentIndex).toBe(-1)
+    expect(undone2.moveHistory.moves).toHaveLength(2) // 履歴は残っている
+    // 新しい手を指す
+    const newStep = executeMove(undone2, { row: 6, col: 6 }, { row: 5, col: 6 }, false)
+    // redo できる手はなくなる（moves が1手のみになる）
+    expect(newStep.moveHistory.moves).toHaveLength(1)
+    expect(newStep.moveHistory.currentIndex).toBe(0)
+  })
+})

--- a/src/lib/shogi/__tests__/moves.test.ts
+++ b/src/lib/shogi/__tests__/moves.test.ts
@@ -1,0 +1,405 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getLegalMoves,
+  generateDropCandidates,
+  getLegalDrops,
+  isInCheck,
+} from '../moves'
+import {
+  createInitialBoard,
+  createInitialCapturedPieces,
+  addCapturedPiece,
+} from '../board'
+import type { Board } from '../types'
+
+// 空の盤面を作るヘルパー
+function emptyBoard(): Board {
+  return Array.from({ length: 9 }, () => Array(9).fill(null))
+}
+
+describe('歩兵 (pawn) の移動', () => {
+  it('先手の歩は前方1マスに移動できる', () => {
+    const board = createInitialBoard()
+    const captured = createInitialCapturedPieces()
+    // row6 の先手歩から合法手を取得（初期配置では駒がブロックしない）
+    const moves = getLegalMoves(board, { row: 6, col: 4 }, captured, 'sente')
+    expect(moves).toHaveLength(1)
+    expect(moves[0]).toEqual({ row: 5, col: 4 })
+  })
+
+  it('先手の歩は後方に移動できない', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'pawn', owner: 'sente' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 4, col: 4 }, captured, 'sente')
+    // 前方（row3）のみ。後方（row5）は含まれない
+    expect(moves.every(m => m.row < 4)).toBe(true)
+    expect(moves.some(m => m.row === 3 && m.col === 4)).toBe(true)
+  })
+
+  it('後手の歩は前方（row増加方向）に移動できる', () => {
+    const board = emptyBoard()
+    board[2][4] = { type: 'pawn', owner: 'gote' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 2, col: 4 }, captured, 'gote')
+    expect(moves).toHaveLength(1)
+    expect(moves[0]).toEqual({ row: 3, col: 4 })
+  })
+})
+
+describe('香車 (lance) の移動', () => {
+  it('先手の香車は前方にスライド移動できる', () => {
+    const board = emptyBoard()
+    board[6][0] = { type: 'lance', owner: 'sente' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 6, col: 0 }, captured, 'sente')
+    // row5, row4, row3, row2, row1 に移動可能（row0は行き所なし）
+    expect(moves.length).toBe(5)
+    expect(moves.some(m => m.row === 5 && m.col === 0)).toBe(true)
+    expect(moves.some(m => m.row === 1 && m.col === 0)).toBe(true)
+  })
+
+  it('先手の香車は途中に味方駒があるとブロックされる', () => {
+    const board = emptyBoard()
+    board[6][0] = { type: 'lance', owner: 'sente' }
+    board[4][0] = { type: 'pawn', owner: 'sente' } // ブロック
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 6, col: 0 }, captured, 'sente')
+    // row5 のみ（row4の手前まで）
+    expect(moves).toHaveLength(1)
+    expect(moves[0]).toEqual({ row: 5, col: 0 })
+  })
+
+  it('先手の香車は相手駒は取れるがその先には進めない', () => {
+    const board = emptyBoard()
+    board[6][0] = { type: 'lance', owner: 'sente' }
+    board[4][0] = { type: 'pawn', owner: 'gote' } // 敵駒
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 6, col: 0 }, captured, 'sente')
+    // row5, row4（敵駒取り）まで
+    expect(moves.some(m => m.row === 4 && m.col === 0)).toBe(true)
+    expect(moves.every(m => m.row >= 4)).toBe(true)
+  })
+})
+
+describe('桂馬 (knight) の移動', () => {
+  it('先手の桂馬はL字型にジャンプできる', () => {
+    const board = emptyBoard()
+    board[8][1] = { type: 'knight', owner: 'sente' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 8, col: 1 }, captured, 'sente')
+    // 桂馬の移動先: { row: 6, col: 0 } と { row: 6, col: 2 }
+    expect(moves.length).toBe(2)
+    expect(moves.some(m => m.row === 6 && m.col === 0)).toBe(true)
+    expect(moves.some(m => m.row === 6 && m.col === 2)).toBe(true)
+  })
+
+  it('桂馬は味方駒のマスに移動できない', () => {
+    const board = emptyBoard()
+    board[8][1] = { type: 'knight', owner: 'sente' }
+    board[6][0] = { type: 'pawn', owner: 'sente' } // ブロック
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 8, col: 1 }, captured, 'sente')
+    // { row: 6, col: 0 } は味方駒があるので行けない
+    expect(moves.some(m => m.row === 6 && m.col === 0)).toBe(false)
+    expect(moves.some(m => m.row === 6 && m.col === 2)).toBe(true)
+  })
+})
+
+describe('銀将 (silver) の移動', () => {
+  it('銀将は5方向に移動できる', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'silver', owner: 'sente' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 4, col: 4 }, captured, 'sente')
+    // 前・左前・右前・左後・右後 の5方向
+    expect(moves).toHaveLength(5)
+    expect(moves.some(m => m.row === 3 && m.col === 4)).toBe(true) // 前
+    expect(moves.some(m => m.row === 3 && m.col === 3)).toBe(true) // 左前
+    expect(moves.some(m => m.row === 3 && m.col === 5)).toBe(true) // 右前
+    expect(moves.some(m => m.row === 5 && m.col === 3)).toBe(true) // 左後
+    expect(moves.some(m => m.row === 5 && m.col === 5)).toBe(true) // 右後
+  })
+})
+
+describe('金将 (gold) の移動', () => {
+  it('金将は6方向に移動できる', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'gold', owner: 'sente' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 4, col: 4 }, captured, 'sente')
+    // 前・左前・右前・左・右・後 の6方向
+    expect(moves).toHaveLength(6)
+    expect(moves.some(m => m.row === 3 && m.col === 4)).toBe(true) // 前
+    expect(moves.some(m => m.row === 3 && m.col === 3)).toBe(true) // 左前
+    expect(moves.some(m => m.row === 3 && m.col === 5)).toBe(true) // 右前
+    expect(moves.some(m => m.row === 4 && m.col === 3)).toBe(true) // 左
+    expect(moves.some(m => m.row === 4 && m.col === 5)).toBe(true) // 右
+    expect(moves.some(m => m.row === 5 && m.col === 4)).toBe(true) // 後
+  })
+})
+
+describe('飛車 (rook) の移動', () => {
+  it('飛車は四方向にスライド移動できる', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'rook', owner: 'sente' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 4, col: 4 }, captured, 'sente')
+    // 前後左右それぞれ最大まで（王のいる行・列は王の手前まで）
+    expect(moves.some(m => m.row === 3 && m.col === 4)).toBe(true)
+    expect(moves.some(m => m.row === 1 && m.col === 4)).toBe(true)
+    expect(moves.some(m => m.row === 5 && m.col === 4)).toBe(true)
+    expect(moves.some(m => m.row === 4 && m.col === 0)).toBe(true)
+    expect(moves.some(m => m.row === 4 && m.col === 8)).toBe(true)
+  })
+
+  it('飛車は味方駒でブロックされる', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'rook', owner: 'sente' }
+    board[4][2] = { type: 'pawn', owner: 'sente' } // 左のブロック
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 4, col: 4 }, captured, 'sente')
+    // col=2 より左（col=1, col=0）には移動できない
+    expect(moves.some(m => m.row === 4 && m.col === 1)).toBe(false)
+    expect(moves.some(m => m.row === 4 && m.col === 0)).toBe(false)
+    // col=3 には移動できる
+    expect(moves.some(m => m.row === 4 && m.col === 3)).toBe(true)
+  })
+
+  it('飛車は敵駒を取れるがその先には進めない', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'rook', owner: 'sente' }
+    board[4][2] = { type: 'pawn', owner: 'gote' } // 敵駒
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 4, col: 4 }, captured, 'sente')
+    // col=2 の敵駒は取れる
+    expect(moves.some(m => m.row === 4 && m.col === 2)).toBe(true)
+    // col=1, col=0 には進めない
+    expect(moves.some(m => m.row === 4 && m.col === 1)).toBe(false)
+  })
+})
+
+describe('角行 (bishop) の移動', () => {
+  it('角行は斜め4方向にスライド移動できる', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'bishop', owner: 'sente' }
+    board[8][0] = { type: 'king', owner: 'sente' }
+    board[0][0] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 4, col: 4 }, captured, 'sente')
+    // 左前方向
+    expect(moves.some(m => m.row === 3 && m.col === 5)).toBe(true)
+    // 右前方向
+    expect(moves.some(m => m.row === 3 && m.col === 3)).toBe(true)
+    // 左後方向
+    expect(moves.some(m => m.row === 5 && m.col === 5)).toBe(true)
+    // 右後方向
+    expect(moves.some(m => m.row === 5 && m.col === 3)).toBe(true)
+  })
+
+  it('角行は味方駒でブロックされ敵駒は取れる', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'bishop', owner: 'sente' }
+    board[2][2] = { type: 'pawn', owner: 'gote' } // 敵駒（右前）
+    board[8][0] = { type: 'king', owner: 'sente' }
+    board[0][8] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 4, col: 4 }, captured, 'sente')
+    // row2, col2 は取れる
+    expect(moves.some(m => m.row === 2 && m.col === 2)).toBe(true)
+    // その先（row1, col1）には進めない
+    expect(moves.some(m => m.row === 1 && m.col === 1)).toBe(false)
+  })
+})
+
+describe('竜王 (promoted_rook) の移動', () => {
+  it('竜王は前後左右スライド + 斜め1マスに移動できる', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'promoted_rook', owner: 'sente' }
+    board[8][0] = { type: 'king', owner: 'sente' }
+    board[0][0] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 4, col: 4 }, captured, 'sente')
+    // スライド移動（前）
+    expect(moves.some(m => m.row === 0 && m.col === 4)).toBe(true)
+    // 斜め1マス（右前）
+    expect(moves.some(m => m.row === 3 && m.col === 3)).toBe(true)
+    // 斜め1マス（左後）
+    expect(moves.some(m => m.row === 5 && m.col === 5)).toBe(true)
+    // 斜め2マスには進めない
+    expect(moves.some(m => m.row === 2 && m.col === 2)).toBe(false)
+  })
+})
+
+describe('竜馬 (promoted_bishop) の移動', () => {
+  it('竜馬は斜めスライド + 前後左右1マスに移動できる', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'promoted_bishop', owner: 'sente' }
+    board[8][0] = { type: 'king', owner: 'sente' }
+    board[0][0] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 4, col: 4 }, captured, 'sente')
+    // 斜めスライド（右前）
+    expect(moves.some(m => m.row === 1 && m.col === 1)).toBe(true)
+    // 前1マス
+    expect(moves.some(m => m.row === 3 && m.col === 4)).toBe(true)
+    // 後1マス
+    expect(moves.some(m => m.row === 5 && m.col === 4)).toBe(true)
+    // 前2マスには進めない（1マス限定）
+    expect(moves.some(m => m.row === 2 && m.col === 4)).toBe(false)
+  })
+})
+
+describe('王将 (king) の移動', () => {
+  it('王将は8方向に1マスずつ移動できる', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    const moves = getLegalMoves(board, { row: 4, col: 4 }, captured, 'sente')
+    // 王手に入らない8方向すべて（この場合、後手の王が遠いので全8方向可能）
+    expect(moves).toHaveLength(8)
+    expect(moves.some(m => m.row === 3 && m.col === 4)).toBe(true) // 前
+    expect(moves.some(m => m.row === 5 && m.col === 4)).toBe(true) // 後
+    expect(moves.some(m => m.row === 4 && m.col === 3)).toBe(true) // 左
+    expect(moves.some(m => m.row === 4 && m.col === 5)).toBe(true) // 右
+    expect(moves.some(m => m.row === 3 && m.col === 3)).toBe(true) // 右前
+    expect(moves.some(m => m.row === 3 && m.col === 5)).toBe(true) // 左前
+    expect(moves.some(m => m.row === 5 && m.col === 3)).toBe(true) // 右後
+    expect(moves.some(m => m.row === 5 && m.col === 5)).toBe(true) // 左後
+  })
+})
+
+describe('getLegalMoves: 王手放置チェック', () => {
+  it('自玉が王手になる手は合法手に含まれない', () => {
+    // 先手の王が row8 col4 にいて、飛車が row0 col4 から王手している状況
+    // 先手の歩を row4 col4 に置いてブロックした場合
+    const board = emptyBoard()
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'rook', owner: 'gote' }
+    board[4][4] = { type: 'pawn', owner: 'sente' } // ブロック駒
+    board[0][0] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    // 歩を横に動かすと王手になる
+    const moves = getLegalMoves(board, { row: 4, col: 4 }, captured, 'sente')
+    // 前進（row3 col4）はOK（王手が続く場合は除外されるが、ここでは飛車の前に移動するのでNG）
+    // 歩の移動可能先: row3 col4 → そこに移動すると col4 のラインが開くので王手放置になる
+    expect(moves.some(m => m.col !== 4)).toBe(false) // col4 以外への移動はない
+  })
+})
+
+describe('generateDropCandidates', () => {
+  it('空のマスの位置をすべて返す', () => {
+    const board = emptyBoard()
+    board[0][0] = { type: 'pawn', owner: 'sente' }
+    const candidates = generateDropCandidates(board)
+    // 81 - 1 = 80 マス
+    expect(candidates).toHaveLength(80)
+    expect(candidates.some(p => p.row === 0 && p.col === 0)).toBe(false)
+    expect(candidates.some(p => p.row === 0 && p.col === 1)).toBe(true)
+  })
+
+  it('すべてのマスが埋まっている場合は空配列を返す', () => {
+    const board = emptyBoard()
+    for (let row = 0; row < 9; row++) {
+      for (let col = 0; col < 9; col++) {
+        board[row][col] = { type: 'pawn', owner: 'sente' }
+      }
+    }
+    const candidates = generateDropCandidates(board)
+    expect(candidates).toHaveLength(0)
+  })
+})
+
+describe('getLegalDrops: 二歩 (nifu) チェック', () => {
+  it('同じ筋に先手の歩がある場合、その筋には歩を打てない', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'pawn', owner: 'sente' } // 先手の歩
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = addCapturedPiece(createInitialCapturedPieces(), 'sente', 'pawn')
+    const drops = getLegalDrops(board, 'sente', 'pawn', captured)
+    // col=4 の空マスには打てない
+    expect(drops.every(p => p.col !== 4)).toBe(true)
+  })
+
+  it('異なる筋には歩を打てる（二歩でない）', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'pawn', owner: 'sente' }
+    board[8][0] = { type: 'king', owner: 'sente' }
+    board[0][8] = { type: 'king', owner: 'gote' }
+    const captured = addCapturedPiece(createInitialCapturedPieces(), 'sente', 'pawn')
+    const drops = getLegalDrops(board, 'sente', 'pawn', captured)
+    // col=3 には打てる（行き所なしの行を除く）
+    expect(drops.some(p => p.col === 3 && p.row > 0)).toBe(true)
+  })
+})
+
+describe('getLegalDrops: 行き所のない駒チェック', () => {
+  it('先手の歩は row0 に打てない', () => {
+    const board = emptyBoard()
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = addCapturedPiece(createInitialCapturedPieces(), 'sente', 'pawn')
+    const drops = getLegalDrops(board, 'sente', 'pawn', captured)
+    expect(drops.every(p => p.row !== 0)).toBe(true)
+  })
+
+  it('先手の香車は row0 に打てない', () => {
+    const board = emptyBoard()
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = addCapturedPiece(createInitialCapturedPieces(), 'sente', 'lance')
+    const drops = getLegalDrops(board, 'sente', 'lance', captured)
+    expect(drops.every(p => p.row !== 0)).toBe(true)
+  })
+
+  it('先手の桂馬は row0 と row1 に打てない', () => {
+    const board = emptyBoard()
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'king', owner: 'gote' }
+    const captured = addCapturedPiece(createInitialCapturedPieces(), 'sente', 'knight')
+    const drops = getLegalDrops(board, 'sente', 'knight', captured)
+    expect(drops.every(p => p.row !== 0 && p.row !== 1)).toBe(true)
+  })
+})
+
+describe('isInCheck', () => {
+  it('飛車による王手を検出する', () => {
+    const board = emptyBoard()
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'rook', owner: 'gote' }
+    board[0][0] = { type: 'king', owner: 'gote' }
+    expect(isInCheck(board, 'sente')).toBe(true)
+  })
+
+  it('王手がかかっていない場合は false を返す', () => {
+    const board = createInitialBoard()
+    expect(isInCheck(board, 'sente')).toBe(false)
+    expect(isInCheck(board, 'gote')).toBe(false)
+  })
+})

--- a/src/lib/shogi/__tests__/rules.test.ts
+++ b/src/lib/shogi/__tests__/rules.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isNifu,
+  hasNoEscape,
+  canPromote,
+  mustPromote,
+  getPromotedType,
+  getDemotedType,
+  isInCheck,
+  isCheckmate,
+  isUchifuzume,
+} from '../rules'
+import {
+  createInitialBoard,
+  createInitialCapturedPieces,
+  addCapturedPiece,
+} from '../board'
+import type { Board, Piece } from '../types'
+
+// 空の盤面を作るヘルパー
+function emptyBoard(): Board {
+  return Array.from({ length: 9 }, () => Array(9).fill(null))
+}
+
+describe('isNifu', () => {
+  it('同じ筋に先手の歩がある場合 true を返す', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'pawn', owner: 'sente' }
+    expect(isNifu(board, 'sente', 4)).toBe(true)
+  })
+
+  it('同じ筋に歩がない場合 false を返す', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'pawn', owner: 'sente' }
+    expect(isNifu(board, 'sente', 5)).toBe(false)
+  })
+
+  it('相手の歩は二歩判定に含まれない', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'pawn', owner: 'gote' }
+    // 先手の二歩判定では後手の歩はカウントしない
+    expect(isNifu(board, 'sente', 4)).toBe(false)
+  })
+
+  it('成り歩（と金）は二歩判定に含まれない', () => {
+    const board = emptyBoard()
+    board[4][4] = { type: 'promoted_pawn', owner: 'sente' }
+    expect(isNifu(board, 'sente', 4)).toBe(false)
+  })
+})
+
+describe('hasNoEscape', () => {
+  it('先手の歩が row0 に移動すると行き所なし', () => {
+    expect(hasNoEscape('pawn', 'sente', { row: 0, col: 4 })).toBe(true)
+  })
+
+  it('先手の香車が row0 に移動すると行き所なし', () => {
+    expect(hasNoEscape('lance', 'sente', { row: 0, col: 4 })).toBe(true)
+  })
+
+  it('先手の桂馬が row1 に移動すると行き所なし', () => {
+    expect(hasNoEscape('knight', 'sente', { row: 1, col: 4 })).toBe(true)
+  })
+
+  it('先手の桂馬が row0 に移動すると行き所なし', () => {
+    expect(hasNoEscape('knight', 'sente', { row: 0, col: 4 })).toBe(true)
+  })
+
+  it('先手の歩が row1 に移動しても行き所なしでない', () => {
+    expect(hasNoEscape('pawn', 'sente', { row: 1, col: 4 })).toBe(false)
+  })
+
+  it('後手の歩が row8 に移動すると行き所なし', () => {
+    expect(hasNoEscape('pawn', 'gote', { row: 8, col: 4 })).toBe(true)
+  })
+
+  it('後手の桂馬が row7 に移動すると行き所なし', () => {
+    expect(hasNoEscape('knight', 'gote', { row: 7, col: 4 })).toBe(true)
+  })
+
+  it('後手の桂馬が row6 に移動しても行き所なしでない', () => {
+    expect(hasNoEscape('knight', 'gote', { row: 6, col: 4 })).toBe(false)
+  })
+
+  it('先手の金将は row0 でも行き所なしでない（金将は行き所なし対象外）', () => {
+    expect(hasNoEscape('gold', 'sente', { row: 0, col: 4 })).toBe(false)
+  })
+})
+
+describe('canPromote', () => {
+  it('先手の歩が敵陣（row2）に入る手は成れる', () => {
+    const piece: Piece = { type: 'pawn', owner: 'sente' }
+    expect(canPromote(piece, { row: 3, col: 4 }, { row: 2, col: 4 })).toBe(true)
+  })
+
+  it('先手の歩が敵陣（row2）から出る手は成れる', () => {
+    const piece: Piece = { type: 'pawn', owner: 'sente' }
+    expect(canPromote(piece, { row: 2, col: 4 }, { row: 3, col: 4 })).toBe(true)
+  })
+
+  it('先手の歩が敵陣外（row3→row4）への移動は成れない', () => {
+    const piece: Piece = { type: 'pawn', owner: 'sente' }
+    expect(canPromote(piece, { row: 4, col: 4 }, { row: 3, col: 4 })).toBe(false)
+  })
+
+  it('金将は成れない', () => {
+    const piece: Piece = { type: 'gold', owner: 'sente' }
+    expect(canPromote(piece, { row: 3, col: 4 }, { row: 2, col: 4 })).toBe(false)
+  })
+
+  it('王将は成れない', () => {
+    const piece: Piece = { type: 'king', owner: 'sente' }
+    expect(canPromote(piece, { row: 3, col: 4 }, { row: 2, col: 4 })).toBe(false)
+  })
+
+  it('既に成っている駒（promoted_pawn）は成れない', () => {
+    const piece: Piece = { type: 'promoted_pawn', owner: 'sente' }
+    expect(canPromote(piece, { row: 3, col: 4 }, { row: 2, col: 4 })).toBe(false)
+  })
+
+  it('後手の歩が敵陣（row6）に入る手は成れる', () => {
+    const piece: Piece = { type: 'pawn', owner: 'gote' }
+    expect(canPromote(piece, { row: 5, col: 4 }, { row: 6, col: 4 })).toBe(true)
+  })
+})
+
+describe('mustPromote', () => {
+  it('先手の歩が row0 に移動するのは強制成り', () => {
+    const piece: Piece = { type: 'pawn', owner: 'sente' }
+    expect(mustPromote(piece, { row: 0, col: 4 })).toBe(true)
+  })
+
+  it('先手の桂馬が row1 に移動するのは強制成り', () => {
+    const piece: Piece = { type: 'knight', owner: 'sente' }
+    expect(mustPromote(piece, { row: 1, col: 4 })).toBe(true)
+  })
+
+  it('先手の桂馬が row2 に移動するのは強制成りでない', () => {
+    const piece: Piece = { type: 'knight', owner: 'sente' }
+    expect(mustPromote(piece, { row: 2, col: 4 })).toBe(false)
+  })
+
+  it('後手の歩が row8 に移動するのは強制成り', () => {
+    const piece: Piece = { type: 'pawn', owner: 'gote' }
+    expect(mustPromote(piece, { row: 8, col: 4 })).toBe(true)
+  })
+
+  it('後手の桂馬が row7 に移動するのは強制成り', () => {
+    const piece: Piece = { type: 'knight', owner: 'gote' }
+    expect(mustPromote(piece, { row: 7, col: 4 })).toBe(true)
+  })
+
+  it('先手の金将は row0 でも強制成りでない', () => {
+    const piece: Piece = { type: 'gold', owner: 'sente' }
+    expect(mustPromote(piece, { row: 0, col: 4 })).toBe(false)
+  })
+})
+
+describe('getPromotedType', () => {
+  it('歩は promoted_pawn になる', () => {
+    expect(getPromotedType('pawn')).toBe('promoted_pawn')
+  })
+
+  it('飛車は promoted_rook になる', () => {
+    expect(getPromotedType('rook')).toBe('promoted_rook')
+  })
+
+  it('角行は promoted_bishop になる', () => {
+    expect(getPromotedType('bishop')).toBe('promoted_bishop')
+  })
+
+  it('銀将は promoted_silver になる', () => {
+    expect(getPromotedType('silver')).toBe('promoted_silver')
+  })
+
+  it('桂馬は promoted_knight になる', () => {
+    expect(getPromotedType('knight')).toBe('promoted_knight')
+  })
+
+  it('香車は promoted_lance になる', () => {
+    expect(getPromotedType('lance')).toBe('promoted_lance')
+  })
+
+  it('王将は null を返す（成れない）', () => {
+    expect(getPromotedType('king')).toBeNull()
+  })
+
+  it('金将は null を返す（成れない）', () => {
+    expect(getPromotedType('gold')).toBeNull()
+  })
+})
+
+describe('getDemotedType', () => {
+  it('promoted_pawn は pawn に戻る', () => {
+    expect(getDemotedType('promoted_pawn')).toBe('pawn')
+  })
+
+  it('promoted_rook は rook に戻る', () => {
+    expect(getDemotedType('promoted_rook')).toBe('rook')
+  })
+
+  it('promoted_bishop は bishop に戻る', () => {
+    expect(getDemotedType('promoted_bishop')).toBe('bishop')
+  })
+
+  it('promoted_silver は silver に戻る', () => {
+    expect(getDemotedType('promoted_silver')).toBe('silver')
+  })
+
+  it('promoted_knight は knight に戻る', () => {
+    expect(getDemotedType('promoted_knight')).toBe('knight')
+  })
+
+  it('promoted_lance は lance に戻る', () => {
+    expect(getDemotedType('promoted_lance')).toBe('lance')
+  })
+})
+
+describe('isInCheck（rules.ts 経由）', () => {
+  it('飛車による王手を検出する', () => {
+    const board = emptyBoard()
+    board[8][4] = { type: 'king', owner: 'sente' }
+    board[0][4] = { type: 'rook', owner: 'gote' }
+    board[0][0] = { type: 'king', owner: 'gote' }
+    expect(isInCheck(board, 'sente')).toBe(true)
+  })
+
+  it('初期盤面では王手がかかっていない', () => {
+    const board = createInitialBoard()
+    expect(isInCheck(board, 'sente')).toBe(false)
+    expect(isInCheck(board, 'gote')).toBe(false)
+  })
+})
+
+describe('isCheckmate', () => {
+  it('詰みの盤面を正しく検出する', () => {
+    // 先手の王（row8 col4）が後手の飛車・金で詰んでいる状況を構築
+    // 王の周囲を全て封じる
+    const board = emptyBoard()
+    board[8][4] = { type: 'king', owner: 'sente' }
+    // 後手の金で逃げ道を塞ぐ
+    board[7][3] = { type: 'gold', owner: 'gote' }
+    board[7][4] = { type: 'gold', owner: 'gote' }
+    board[7][5] = { type: 'gold', owner: 'gote' }
+    board[8][3] = { type: 'gold', owner: 'gote' }
+    board[8][5] = { type: 'gold', owner: 'gote' }
+    // 後手の飛車で王手
+    board[6][4] = { type: 'rook', owner: 'gote' }
+    board[0][0] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    expect(isCheckmate(board, captured, 'sente')).toBe(true)
+  })
+
+  it('詰みでない場合は false を返す', () => {
+    const board = createInitialBoard()
+    const captured = createInitialCapturedPieces()
+    expect(isCheckmate(board, captured, 'sente')).toBe(false)
+  })
+
+  it('王手でなくても合法手がなければ詰み', () => {
+    // 先手の王だけ。後手の駒に包囲されて動けない状況
+    const board = emptyBoard()
+    board[8][4] = { type: 'king', owner: 'sente' }
+    // 全8方向を後手の金で封鎖（王手はかけずに包囲）
+    board[7][3] = { type: 'gold', owner: 'gote' }
+    board[7][4] = { type: 'gold', owner: 'gote' }
+    board[7][5] = { type: 'gold', owner: 'gote' }
+    board[8][3] = { type: 'gold', owner: 'gote' }
+    board[8][5] = { type: 'gold', owner: 'gote' }
+    // 飛車で王手
+    board[6][4] = { type: 'rook', owner: 'gote' }
+    board[0][0] = { type: 'king', owner: 'gote' }
+    const captured = createInitialCapturedPieces()
+    expect(isCheckmate(board, captured, 'sente')).toBe(true)
+  })
+})
+
+describe('isUchifuzume', () => {
+  it('歩を打って相手が詰む場合は打ち歩詰め（true）', () => {
+    // 後手の王（row0 col4）が逃げられない状況で先手が歩を打つケース
+    const board = emptyBoard()
+    board[0][4] = { type: 'king', owner: 'gote' }
+    // 逃げ道を塞ぐ
+    board[0][3] = { type: 'gold', owner: 'sente' }
+    board[0][5] = { type: 'gold', owner: 'sente' }
+    board[1][3] = { type: 'gold', owner: 'sente' }
+    board[1][5] = { type: 'gold', owner: 'sente' }
+    // row1 col4 に歩を打って詰み（打ち歩詰め）
+    board[8][4] = { type: 'king', owner: 'sente' }
+    const captured = addCapturedPiece(createInitialCapturedPieces(), 'sente', 'pawn')
+    // pos = { row: 1, col: 4 } に歩を打つ
+    expect(isUchifuzume(board, 'sente', { row: 1, col: 4 }, captured)).toBe(true)
+  })
+
+  it('歩を打っても相手に逃げ道がある場合は打ち歩詰めでない（false）', () => {
+    const board = emptyBoard()
+    board[0][4] = { type: 'king', owner: 'gote' }
+    board[8][4] = { type: 'king', owner: 'sente' }
+    // 逃げ道が開いている（側面は空き）
+    const captured = addCapturedPiece(createInitialCapturedPieces(), 'sente', 'pawn')
+    expect(isUchifuzume(board, 'sente', { row: 1, col: 4 }, captured)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- `board.test.ts` (30件): createInitialBoard・cloneBoard独立性・getPieceAt・setPieceAt・removePieceAt・findKing・addCapturedPiece・consumeCapturedPiece・createInitialCapturedPieces
- `moves.test.ts` (28件): 全駒種移動パターン・スライド遮断・桂馬ジャンプ・後手方向反転・getLegalMoves王手放置除外・getLegalDrops禁手チェック
- `rules.test.ts` (47件): isNifu・hasNoEscape・canPromote・mustPromote・getPromotedType・getDemotedType・isInCheck・isCheckmate・isUchifuzume
- `game.test.ts` (30件): createInitialGameState・executeMove・executeDrop・undoMove・redoMove・履歴管理・Redo枝刈り

## Test plan
- [x] `npm run lint` PASS（error 0）
- [x] `npm run test:run` PASS（135 tests, 4 files）
- [x] `npm run build` PASS

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)