### PR TITLE
feat: 盤面コンポーネント（Board・Square）実装 (#9)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,65 +1,62 @@
-import Image from "next/image";
+'use client'
+
+import { Board } from '@/components/Board'
+import { useGameStore } from '@/stores/gameStore'
+import type { Position } from '@/lib/shogi/types'
+import { getPieceAt } from '@/lib/shogi/board'
 
 export default function Home() {
+  const { gameState, startNewGame, selectPiece, deselectPiece, movePiece, dropPiece } =
+    useGameStore()
+  const { board, currentPlayer, selectedPosition, legalMoves, moveHistory, phase } = gameState
+
+  const lastMove =
+    moveHistory.currentIndex >= 0 ? moveHistory.moves[moveHistory.currentIndex] : null
+
+  const handleSquareClick = (pos: Position) => {
+    if (phase === 'idle' || phase === 'piece_selected') {
+      const piece = getPieceAt(board, pos)
+      if (piece?.owner === currentPlayer) {
+        selectPiece(pos)
+      } else if (phase === 'piece_selected') {
+        const isLegal = legalMoves.some((p) => p.row === pos.row && p.col === pos.col)
+        if (isLegal) {
+          movePiece(pos)
+        } else {
+          deselectPiece()
+        }
+      }
+    } else if (phase === 'captured_selected') {
+      dropPiece(pos)
+    }
+  }
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-stone-100 p-4">
+      <h1 className="text-2xl font-bold text-amber-900">しょうぎゅー！</h1>
+
+      <button
+        className="rounded-lg bg-amber-700 px-6 py-2 font-semibold text-white hover:bg-amber-800"
+        onClick={startNewGame}
+      >
+        あそぶ！
+      </button>
+
+      {/* 盤面: 高さ基準で正方形にする */}
+      <div className="w-[min(65svh,90svw)]">
+        <Board
+          board={board}
+          currentPlayer={currentPlayer}
+          selectedPosition={selectedPosition}
+          legalMoves={legalMoves}
+          lastMove={lastMove}
+          onSquareClick={handleSquareClick}
         />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
-    </div>
-  );
+      </div>
+
+      <p className="text-sm font-medium text-amber-800">
+        手番: {currentPlayer === 'sente' ? '先手（青）' : '後手（赤）'} / phase: {phase}
+      </p>
+    </main>
+  )
 }

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import type { Board as BoardType, Move, Piece, Player, Position } from '@/lib/shogi/types'
+import { Square } from './Square'
+
+// ============================================================
+// 定数
+// ============================================================
+
+const DAN_LABELS = ['一', '二', '三', '四', '五', '六', '七', '八', '九']
+
+/** #10 で Piece コンポーネントに置き換えるまでの暫定ラベル */
+const PIECE_LABEL: Record<string, string> = {
+  king: '王',
+  rook: '飛',
+  bishop: '角',
+  gold: '金',
+  silver: '銀',
+  knight: '桂',
+  lance: '香',
+  pawn: '歩',
+  promoted_rook: '竜',
+  promoted_bishop: '馬',
+  promoted_silver: '全',
+  promoted_knight: '圭',
+  promoted_lance: '杏',
+  promoted_pawn: 'と',
+}
+
+// ============================================================
+// ヘルパー関数
+// ============================================================
+
+/**
+ * 表示座標 → 内部座標
+ * - 先手: そのまま
+ * - 後手: row / col を反転（盤面が180度回転した視点）
+ */
+function toInternalPos(displayRow: number, displayCol: number, currentPlayer: Player): Position {
+  if (currentPlayer === 'sente') return { row: displayRow, col: displayCol }
+  return { row: 8 - displayRow, col: 8 - displayCol }
+}
+
+/** 表示列インデックス → 筋ラベル（数字） */
+function colLabel(displayCol: number, currentPlayer: Player): number {
+  return currentPlayer === 'sente' ? 9 - displayCol : displayCol + 1
+}
+
+/** 表示行インデックス → 段ラベル（漢字） */
+function rowLabel(displayRow: number, currentPlayer: Player): string {
+  return currentPlayer === 'sente' ? DAN_LABELS[displayRow] : DAN_LABELS[8 - displayRow]
+}
+
+// ============================================================
+// 型定義
+// ============================================================
+
+interface BoardProps {
+  board: BoardType
+  currentPlayer: Player
+  selectedPosition: Position | null
+  legalMoves: Position[]
+  lastMove: Move | null
+  onSquareClick: (pos: Position) => void
+}
+
+// ============================================================
+// Board コンポーネント
+// ============================================================
+
+export function Board({
+  board,
+  currentPlayer,
+  selectedPosition,
+  legalMoves,
+  lastMove,
+  onSquareClick,
+}: BoardProps) {
+  // Set に変換しておくことでO(1)ルックアップを実現
+  const legalMoveSet = new Set(legalMoves.map((p) => `${p.row},${p.col}`))
+
+  const lastMoveFrom = lastMove?.type === 'move' ? lastMove.from : null
+  const lastMoveTo = lastMove?.to ?? null
+
+  return (
+    <div className="inline-flex flex-col select-none">
+      {/* 筋ラベル（9〜1 または 1〜9） */}
+      <div className="flex pr-6">
+        {Array.from({ length: 9 }, (_, displayCol) => (
+          <div
+            key={displayCol}
+            className="flex-1 text-center text-xs font-medium text-amber-900"
+          >
+            {colLabel(displayCol, currentPlayer)}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex">
+        {/* 9x9 盤面グリッド */}
+        <div className="grid flex-1 grid-cols-9 border-l-2 border-t-2 border-amber-900">
+          {Array.from({ length: 81 }, (_, i) => {
+            const displayRow = Math.floor(i / 9)
+            const displayCol = i % 9
+            const internalPos = toInternalPos(displayRow, displayCol, currentPlayer)
+            const posKey = `${internalPos.row},${internalPos.col}`
+
+            const piece = board[internalPos.row][internalPos.col]
+            const isSelected =
+              selectedPosition?.row === internalPos.row &&
+              selectedPosition?.col === internalPos.col
+            const isLegalMove = legalMoveSet.has(posKey)
+            const isCapturable =
+              isLegalMove && piece !== null && piece.owner !== currentPlayer
+            const isLastMoveFrom =
+              lastMoveFrom?.row === internalPos.row &&
+              lastMoveFrom?.col === internalPos.col
+            const isLastMoveTo =
+              lastMoveTo?.row === internalPos.row &&
+              lastMoveTo?.col === internalPos.col
+
+            return (
+              <Square
+                key={posKey}
+                isSelected={isSelected}
+                isLegalMove={isLegalMove}
+                isCapturable={isCapturable}
+                isLastMoveFrom={isLastMoveFrom}
+                isLastMoveTo={isLastMoveTo}
+                onClick={() => onSquareClick(internalPos)}
+              >
+                {piece && <PiecePlaceholder piece={piece} currentPlayer={currentPlayer} />}
+              </Square>
+            )
+          })}
+        </div>
+
+        {/* 段ラベル（一〜九 または 九〜一） */}
+        <div className="flex w-6 flex-col border-t-2 border-amber-900">
+          {Array.from({ length: 9 }, (_, displayRow) => (
+            <div
+              key={displayRow}
+              className="flex flex-1 items-center justify-center text-xs font-medium text-amber-900"
+            >
+              {rowLabel(displayRow, currentPlayer)}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================
+// 暫定駒表示（#10 の Piece コンポーネントに置き換え予定）
+// ============================================================
+
+function PiecePlaceholder({
+  piece,
+  currentPlayer,
+}: {
+  piece: Piece
+  currentPlayer: Player
+}) {
+  const isOpponent = piece.owner !== currentPlayer
+  return (
+    <span
+      className={[
+        'text-[0.65rem] font-bold leading-none',
+        isOpponent ? 'rotate-180' : '',
+        piece.owner === 'sente' ? 'text-blue-900' : 'text-red-900',
+      ].join(' ')}
+    >
+      {PIECE_LABEL[piece.type] ?? piece.type}
+    </span>
+  )
+}

--- a/src/components/Board/Square.tsx
+++ b/src/components/Board/Square.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+interface SquareProps {
+  /** Piece component を差し込むスロット（#10 で Piece コンポーネントに置き換え） */
+  children?: React.ReactNode
+  isSelected: boolean
+  isLegalMove: boolean
+  /** legalMove かつ敵駒がいるマス（赤ハイライト） */
+  isCapturable: boolean
+  isLastMoveFrom: boolean
+  isLastMoveTo: boolean
+  onClick: () => void
+}
+
+export function Square({
+  children,
+  isSelected,
+  isLegalMove,
+  isCapturable,
+  isLastMoveFrom,
+  isLastMoveTo,
+  onClick,
+}: SquareProps) {
+  let bgClass = 'bg-amber-200'
+  if (isSelected) bgClass = 'bg-sky-300'
+  else if (isLastMoveTo) bgClass = 'bg-yellow-300'
+  else if (isLastMoveFrom) bgClass = 'bg-yellow-200'
+
+  return (
+    <div
+      className={`relative flex aspect-square items-center justify-center border-r border-b border-amber-900/50 cursor-pointer select-none ${bgClass}`}
+      onClick={onClick}
+    >
+      {/* 取れる駒ハイライト（赤） */}
+      {isCapturable && (
+        <div className="pointer-events-none absolute inset-0 rounded-sm bg-red-400/40" />
+      )}
+
+      {/* 合法手ドット（緑） */}
+      {isLegalMove && !isCapturable && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="h-[45%] w-[45%] rounded-full bg-green-600/40" />
+        </div>
+      )}
+
+      {children}
+    </div>
+  )
+}

--- a/src/components/Board/index.ts
+++ b/src/components/Board/index.ts
@@ -1,0 +1,2 @@
+export { Board } from './Board'
+export { Square } from './Square'


### PR DESCRIPTION
## Summary
- `Square`: 選択/合法手/取れる駒/直前の手の各ハイライト状態を実装。`children` スロットを持ち、#10 で Piece コンポーネントに差し替え可能
- `Board`: 9x9 CSS Grid、筋（列）・段（行）ラベル、手番に応じた座標変換（先手/後手視点切替）、暫定テキスト駒表示
- `onSquareClick` を props で受け取る設計（Plan A）。#18 ゲームフロー統合でストアと接続
- `page.tsx` を `useGameStore` と接続したデモ画面に更新（駒選択・移動の動作確認が可能）

## 設計上の決定事項
- **props-based 設計**: `onSquareClick: (pos: Position) => void` を外部から受け取る。ストアへの直接依存なし
- **座標変換**: `toInternalPos()` で表示座標→内部座標を変換。後手視点時は row/col を反転
- **isCapturable**: Board 内で `piece.owner !== currentPlayer` を判定し、赤ハイライトを表示
- **PiecePlaceholder**: `#10` 実装まで暫定のテキスト表示。`isOpponent` なら 180 度回転

## Test plan
- [ ] `あそぶ！` ボタンを押して盤面が表示されること
- [ ] 駒をタップすると合法手マスが緑円でハイライトされること
- [ ] 取れる駒のマスが赤でハイライトされること
- [ ] 駒を移動すると直前の手が黄色でハイライトされること
- [ ] 手番交代後に盤面の視点が切り替わること（座標ラベルが反転）
- [ ] 筋ラベル（9〜1）・段ラベル（一〜九）が正しい向きで表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)