### PR TITLE
feat: 駒コンポーネント（Piece）実装 (#10)

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -1,31 +1,14 @@
 'use client'
 
-import type { Board as BoardType, Move, Piece, Player, Position } from '@/lib/shogi/types'
+import type { Board as BoardType, Move, Player, Position } from '@/lib/shogi/types'
 import { Square } from './Square'
+import { Piece } from '@/components/Piece'
 
 // ============================================================
 // 定数
 // ============================================================
 
 const DAN_LABELS = ['一', '二', '三', '四', '五', '六', '七', '八', '九']
-
-/** #10 で Piece コンポーネントに置き換えるまでの暫定ラベル */
-const PIECE_LABEL: Record<string, string> = {
-  king: '王',
-  rook: '飛',
-  bishop: '角',
-  gold: '金',
-  silver: '銀',
-  knight: '桂',
-  lance: '香',
-  pawn: '歩',
-  promoted_rook: '竜',
-  promoted_bishop: '馬',
-  promoted_silver: '全',
-  promoted_knight: '圭',
-  promoted_lance: '杏',
-  promoted_pawn: 'と',
-}
 
 // ============================================================
 // ヘルパー関数
@@ -129,7 +112,13 @@ export function Board({
                 isLastMoveTo={isLastMoveTo}
                 onClick={() => onSquareClick(internalPos)}
               >
-                {piece && <PiecePlaceholder piece={piece} currentPlayer={currentPlayer} />}
+                {piece && (
+                  <Piece
+                    piece={piece}
+                    isSelected={isSelected}
+                    isOpponent={piece.owner !== currentPlayer}
+                  />
+                )}
               </Square>
             )
           })}
@@ -151,27 +140,3 @@ export function Board({
   )
 }
 
-// ============================================================
-// 暫定駒表示（#10 の Piece コンポーネントに置き換え予定）
-// ============================================================
-
-function PiecePlaceholder({
-  piece,
-  currentPlayer,
-}: {
-  piece: Piece
-  currentPlayer: Player
-}) {
-  const isOpponent = piece.owner !== currentPlayer
-  return (
-    <span
-      className={[
-        'text-[0.65rem] font-bold leading-none',
-        isOpponent ? 'rotate-180' : '',
-        piece.owner === 'sente' ? 'text-blue-900' : 'text-red-900',
-      ].join(' ')}
-    >
-      {PIECE_LABEL[piece.type] ?? piece.type}
-    </span>
-  )
-}

--- a/src/components/Piece/Piece.tsx
+++ b/src/components/Piece/Piece.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import type { Piece as PieceType } from '@/lib/shogi/types'
+import { PIECE_CONFIG, isPromotedType } from './pieceConfig'
+
+interface PieceProps {
+  piece: PieceType
+  /** 選択中: 光彩 + バウンスアニメーション */
+  isSelected?: boolean
+  /** 相手の駒: 180度回転表示 */
+  isOpponent?: boolean
+}
+
+export function Piece({ piece, isSelected = false, isOpponent = false }: PieceProps) {
+  const config = PIECE_CONFIG[piece.type]
+  const promoted = isPromotedType(piece.type)
+  const isSente = piece.owner === 'sente'
+
+  // 成駒: 金色枠 / 通常: 先後の色枠
+  const ringClass = promoted
+    ? 'ring-2 ring-yellow-400'
+    : isSente
+      ? 'ring-1 ring-blue-300'
+      : 'ring-1 ring-red-300'
+
+  // 先手=青系、後手=赤系
+  const colorClass = isSente
+    ? 'bg-blue-50 text-blue-900'
+    : 'bg-red-50 text-red-900'
+
+  return (
+    <motion.div
+      className={`flex h-full w-full flex-col items-center justify-center rounded-sm ${ringClass} ${colorClass}`}
+      style={{
+        // 後手の駒は上下反転（盤面座標変換と連動）
+        rotate: isOpponent ? 180 : 0,
+        // 選択中: 金色の光彩
+        filter: isSelected ? 'drop-shadow(0 0 5px rgba(251,191,36,0.95))' : 'none',
+      }}
+      // 選択中: 上下バウンスアニメーション
+      animate={{ y: isSelected ? [0, -4, 0] : 0 }}
+      transition={
+        isSelected
+          ? { duration: 0.5, repeat: Infinity, ease: 'easeInOut' }
+          : { duration: 0.15 }
+      }
+    >
+      <span className="text-base leading-none">{config.emoji}</span>
+      <span className="text-[9px] font-bold leading-none">{config.hiragana}</span>
+    </motion.div>
+  )
+}

--- a/src/components/Piece/index.ts
+++ b/src/components/Piece/index.ts
@@ -1,0 +1,3 @@
+export { Piece } from './Piece'
+export { PIECE_CONFIG, isPromotedType } from './pieceConfig'
+export type { PieceConfig } from './pieceConfig'

--- a/src/components/Piece/pieceConfig.ts
+++ b/src/components/Piece/pieceConfig.ts
@@ -1,0 +1,31 @@
+import type { PieceType, PromotedPieceType } from '@/lib/shogi/types'
+
+export interface PieceConfig {
+  /** 動物絵文字（SVG実装までのプレースホルダ） */
+  emoji: string
+  /** 駒名のひらがな */
+  hiragana: string
+}
+
+export const PIECE_CONFIG: Record<PieceType | PromotedPieceType, PieceConfig> = {
+  // 通常駒
+  king:   { emoji: '🦁', hiragana: 'おう'   },
+  rook:   { emoji: '🦅', hiragana: 'ひしゃ' },
+  bishop: { emoji: '🦉', hiragana: 'かく'   },
+  gold:   { emoji: '🐘', hiragana: 'きん'   },
+  silver: { emoji: '🐺', hiragana: 'ぎん'   },
+  knight: { emoji: '🐰', hiragana: 'けいま' },
+  lance:  { emoji: '🐗', hiragana: 'きょう' },
+  pawn:   { emoji: '🐤', hiragana: 'ふ'     },
+  // 成駒（promoted_ prefix）
+  promoted_rook:   { emoji: '🦅', hiragana: 'りゅう' },
+  promoted_bishop: { emoji: '🦉', hiragana: 'うま'   },
+  promoted_silver: { emoji: '🐺', hiragana: 'なぎん' },
+  promoted_knight: { emoji: '🐰', hiragana: 'なけい' },
+  promoted_lance:  { emoji: '🐗', hiragana: 'なきょ' },
+  promoted_pawn:   { emoji: '🐔', hiragana: 'ときん' },
+}
+
+export function isPromotedType(type: PieceType | PromotedPieceType): boolean {
+  return type.startsWith('promoted_')
+}


### PR DESCRIPTION
## Summary
- `pieceConfig.ts`: 14種の駒（通常8種 + 成駒6種）を絵文字・ひらがな名にマッピング
- `Piece.tsx`: 先手=青系 / 後手=赤系の色分け、成駒=金色枠（`ring-yellow-400`）、選択中=光彩エフェクト + バウンスアニメーション（Framer Motion）、後手駒=180度回転
- `Board.tsx`: `PiecePlaceholder` を `Piece` コンポーネントに差し替え（スコープ拡張）

## 設計上の決定事項
- **`isOpponent` prop**: Board が `piece.owner !== currentPlayer` を計算して渡す。Piece はロジックを持たず表示のみ
- **アニメーション**: `rotate` は `style` prop、バウンス `y` は `animate` prop に分離することで Framer Motion が正しく合成
- **成駒の区別**: `isPromotedType()` で `promoted_` prefix を判定。promoted_rook/bishop は同じ絵文字 + 金色枠で差別化

## Test plan
- [ ] 全14種の駒が絵文字＋ひらがなで表示されること
- [ ] 先手の駒が青系、後手の駒が赤系で表示されること
- [ ] 成駒に金色枠が表示されること
- [ ] 駒を選択すると光彩 + バウンスアニメーションが動作すること
- [ ] 後手視点（手番交代後）で相手駒が正しく180度回転して表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)