### PR TITLE
feat: 持ち駒エリアコンポーネント実装 (#11)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,33 @@
 'use client'
 
 import { Board } from '@/components/Board'
+import { CapturedPieces } from '@/components/CapturedPieces'
 import { useGameStore } from '@/stores/gameStore'
-import type { Position } from '@/lib/shogi/types'
+import type { Player, Position, PieceType } from '@/lib/shogi/types'
 import { getPieceAt } from '@/lib/shogi/board'
 
 export default function Home() {
-  const { gameState, startNewGame, selectPiece, deselectPiece, movePiece, dropPiece } =
-    useGameStore()
-  const { board, currentPlayer, selectedPosition, legalMoves, moveHistory, phase } = gameState
+  const {
+    gameState,
+    startNewGame,
+    selectPiece,
+    selectCapturedPiece,
+    deselectPiece,
+    movePiece,
+    dropPiece,
+  } = useGameStore()
+  const {
+    board,
+    currentPlayer,
+    selectedPosition,
+    selectedCaptured,
+    legalMoves,
+    moveHistory,
+    phase,
+    capturedPieces,
+  } = gameState
 
+  const opponent: Player = currentPlayer === 'sente' ? 'gote' : 'sente'
   const lastMove =
     moveHistory.currentIndex >= 0 ? moveHistory.moves[moveHistory.currentIndex] : null
 
@@ -31,8 +49,18 @@ export default function Home() {
     }
   }
 
+  const handleCapturedSelect = (pieceType: PieceType) => {
+    if (phase !== 'idle' && phase !== 'captured_selected') return
+    // 同じ持ち駒を再タップで解除
+    if (selectedCaptured === pieceType) {
+      deselectPiece()
+    } else {
+      selectCapturedPiece(pieceType)
+    }
+  }
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-stone-100 p-4">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-2 bg-stone-100 p-4">
       <h1 className="text-2xl font-bold text-amber-900">しょうぎゅー！</h1>
 
       <button
@@ -42,8 +70,19 @@ export default function Home() {
         あそぶ！
       </button>
 
-      {/* 盤面: 高さ基準で正方形にする */}
-      <div className="w-[min(65svh,90svw)]">
+      <div className="flex w-[min(65svh,90svw)] flex-col gap-1">
+        {/* 相手の持ち駒エリア（上） */}
+        <div className="h-[12svh]">
+          <CapturedPieces
+            capturedPieces={capturedPieces}
+            owner={opponent}
+            selectedCaptured={selectedCaptured}
+            isOwnerTurn={false}
+            onSelect={handleCapturedSelect}
+          />
+        </div>
+
+        {/* 盤面 */}
         <Board
           board={board}
           currentPlayer={currentPlayer}
@@ -52,6 +91,17 @@ export default function Home() {
           lastMove={lastMove}
           onSquareClick={handleSquareClick}
         />
+
+        {/* 自分の持ち駒エリア（下） */}
+        <div className="h-[12svh]">
+          <CapturedPieces
+            capturedPieces={capturedPieces}
+            owner={currentPlayer}
+            selectedCaptured={selectedCaptured}
+            isOwnerTurn={phase === 'idle' || phase === 'captured_selected'}
+            onSelect={handleCapturedSelect}
+          />
+        </div>
       </div>
 
       <p className="text-sm font-medium text-amber-800">

--- a/src/components/CapturedPieces/CapturedPieces.tsx
+++ b/src/components/CapturedPieces/CapturedPieces.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import type { CapturedPieces as CapturedPiecesType, PieceType, Player } from '@/lib/shogi/types'
+import { PIECE_CONFIG } from '@/components/Piece'
+
+// 表示順（金/銀/桂/香/飛/角/歩）
+const PIECE_ORDER: PieceType[] = ['gold', 'silver', 'knight', 'lance', 'rook', 'bishop', 'pawn']
+
+interface CapturedPiecesProps {
+  capturedPieces: CapturedPiecesType
+  /** このエリアの所有プレイヤー */
+  owner: Player
+  /** 現在選択中の持ち駒の種類 */
+  selectedCaptured: PieceType | null
+  /** このエリアのプレイヤーが手番か */
+  isOwnerTurn: boolean
+  /** 持ち駒タップ時のハンドラ */
+  onSelect: (pieceType: PieceType) => void
+}
+
+export function CapturedPieces({
+  capturedPieces,
+  owner,
+  selectedCaptured,
+  isOwnerTurn,
+  onSelect,
+}: CapturedPiecesProps) {
+  const pieces = capturedPieces[owner]
+  const isSente = owner === 'sente'
+
+  return (
+    <div className="flex h-full w-full items-center justify-around px-1">
+      {PIECE_ORDER.map((pieceType) => {
+        const count = pieces[pieceType] ?? 0
+        const hasCount = count > 0
+        const isSelected = isOwnerTurn && selectedCaptured === pieceType
+        const isClickable = isOwnerTurn && hasCount
+
+        return (
+          <div
+            key={pieceType}
+            className="relative flex h-full max-h-[52px] flex-1 cursor-pointer items-center justify-center"
+            onClick={() => isClickable && onSelect(pieceType)}
+          >
+            <div
+              className={[
+                'flex h-full w-full flex-col items-center justify-center rounded-sm transition-opacity',
+                // 色分け（先手=青系、後手=赤系）
+                isSente ? 'bg-blue-50 ring-1 ring-blue-200' : 'bg-red-50 ring-1 ring-red-200',
+                // 選択中: 金色ハイライト
+                isSelected ? 'ring-2 ring-yellow-400 bg-yellow-50' : '',
+                // 0枚: グレーアウト
+                !hasCount ? 'opacity-30' : '',
+                isClickable ? 'hover:brightness-95' : 'cursor-default',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+            >
+              <span className="text-base leading-none">{PIECE_CONFIG[pieceType].emoji}</span>
+              <span className={`text-[8px] font-bold leading-none ${isSente ? 'text-blue-900' : 'text-red-900'}`}>
+                {PIECE_CONFIG[pieceType].hiragana}
+              </span>
+            </div>
+
+            {/* 枚数バッジ */}
+            {hasCount && (
+              <span className="absolute -right-0.5 -top-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-amber-700 text-[9px] font-bold text-white">
+                {count}
+              </span>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/CapturedPieces/index.ts
+++ b/src/components/CapturedPieces/index.ts
@@ -1,0 +1,1 @@
+export { CapturedPieces } from './CapturedPieces'


### PR DESCRIPTION
## Summary
- `CapturedPieces.tsx`: 7種の持ち駒を横並び固定位置に表示（金/銀/桂/香/飛/角/歩）
- 0枚はグレーアウト（`opacity-30`）で位置固定、枚数バッジ（`bg-amber-700`の丸バッジ）
- 選択中は金色枠（`ring-yellow-400`）でハイライト
- `isOwnerTurn` で操作可否を制御（相手の手番中は触れない）
- `page.tsx`: 盤面の上下に持ち駒エリアを配置（`h-[12svh]`）

## 設計上の決定事項
- **props-based 設計**: Board (#9) と同じ方針。`onSelect` を外部から渡す
- **再タップで解除**: `selectedCaptured === pieceType` の場合は `deselectPiece()` を呼ぶ（page.tsx 側で実装）
- **Piece コンポーネント不使用**: 持ち駒エリアは回転不要・サイズ異なるため `pieceConfig` を直接参照

## Test plan
- [ ] `あそぶ！` 後、盤面の上下に持ち駒エリアが表示されること
- [ ] 初期状態では全スロットがグレーアウトされること
- [ ] 駒を取った後、対応するスロットに枚数バッジが表示されること
- [ ] 持ち駒タップで選択（金色枠）→ 再タップで解除できること
- [ ] 相手の手番中は上エリアの持ち駒がタップできないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)