### PR TITLE
feat: 移動矢印・操作バーコンポーネント実装 (#12)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { Board } from '@/components/Board'
 import { CapturedPieces } from '@/components/CapturedPieces'
+import { ControlBar } from '@/components/Controls'
 import { useGameStore } from '@/stores/gameStore'
 import type { Player, Position, PieceType } from '@/lib/shogi/types'
 import { getPieceAt } from '@/lib/shogi/board'
@@ -15,6 +16,9 @@ export default function Home() {
     deselectPiece,
     movePiece,
     dropPiece,
+    undo,
+    redo,
+    toggleMenu,
   } = useGameStore()
   const {
     board,
@@ -30,6 +34,9 @@ export default function Home() {
   const opponent: Player = currentPlayer === 'sente' ? 'gote' : 'sente'
   const lastMove =
     moveHistory.currentIndex >= 0 ? moveHistory.moves[moveHistory.currentIndex] : null
+
+  const canUndo = moveHistory.currentIndex >= 0 && phase === 'idle'
+  const canRedo = moveHistory.currentIndex < moveHistory.moves.length - 1 && phase === 'idle'
 
   const handleSquareClick = (pos: Position) => {
     if (phase === 'idle' || phase === 'piece_selected') {
@@ -102,11 +109,19 @@ export default function Home() {
             onSelect={handleCapturedSelect}
           />
         </div>
-      </div>
 
-      <p className="text-sm font-medium text-amber-800">
-        手番: {currentPlayer === 'sente' ? '先手（青）' : '後手（赤）'} / phase: {phase}
-      </p>
+        {/* 操作バー */}
+        <div className="h-[8svh]">
+          <ControlBar
+            currentPlayer={currentPlayer}
+            canUndo={canUndo}
+            canRedo={canRedo}
+            onUndo={undo}
+            onRedo={redo}
+            onMenu={toggleMenu}
+          />
+        </div>
+      </div>
     </main>
   )
 }

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -3,6 +3,7 @@
 import type { Board as BoardType, Move, Player, Position } from '@/lib/shogi/types'
 import { Square } from './Square'
 import { Piece } from '@/components/Piece'
+import { MoveArrows } from './MoveArrows'
 
 // ============================================================
 // 定数
@@ -119,6 +120,7 @@ export function Board({
                     isOpponent={piece.owner !== currentPlayer}
                   />
                 )}
+                {isSelected && piece && <MoveArrows piece={piece} />}
               </Square>
             )
           })}

--- a/src/components/Board/MoveArrows.tsx
+++ b/src/components/Board/MoveArrows.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import type { Piece } from '@/lib/shogi/types'
+import { MOVE_PATTERNS } from '@/lib/shogi/moves'
+
+// (dRow, dCol) → 3x3グリッドの位置とユニコード矢印のマッピング
+// dRow/dColは正規化（Math.sign）済みで扱う
+const GRID_ARROWS = [
+  { dRow: -1, dCol: -1, gridCol: 1, gridRow: 1, arrow: '↖' },
+  { dRow: -1, dCol:  0, gridCol: 2, gridRow: 1, arrow: '↑' },
+  { dRow: -1, dCol: +1, gridCol: 3, gridRow: 1, arrow: '↗' },
+  { dRow:  0, dCol: -1, gridCol: 1, gridRow: 2, arrow: '←' },
+  // (2,2) = 中央 = 駒の位置
+  { dRow:  0, dCol: +1, gridCol: 3, gridRow: 2, arrow: '→' },
+  { dRow: +1, dCol: -1, gridCol: 1, gridRow: 3, arrow: '↙' },
+  { dRow: +1, dCol:  0, gridCol: 2, gridRow: 3, arrow: '↓' },
+  { dRow: +1, dCol: +1, gridCol: 3, gridRow: 3, arrow: '↘' },
+] as const
+
+interface MoveArrowsProps {
+  piece: Piece
+}
+
+/**
+ * 選択駒の移動可能方向を矢印で示すオーバーレイ。
+ * Square の absolute inset-0 に配置する想定。
+ *
+ * 桂馬の跳び（dRow=-2）は Math.sign で正規化して ↖/↗ として表示する。
+ * 正確な到達マスは合法手ハイライト（緑丸）で補完するため、
+ * 矢印は「大まかな方向」を示す程度で許容。
+ */
+export function MoveArrows({ piece }: MoveArrowsProps) {
+  const pattern = MOVE_PATTERNS[piece.type]
+
+  // 全方向（steps + slides）を正規化して方向セットを構築
+  const activeDirections = new Set<string>()
+  for (const dir of [...pattern.steps, ...pattern.slides]) {
+    const dRow = Math.sign(dir.dRow)
+    const dCol = Math.sign(dir.dCol)
+    if (dRow === 0 && dCol === 0) continue
+    activeDirections.add(`${dRow},${dCol}`)
+  }
+
+  return (
+    <div className="pointer-events-none absolute inset-0 grid grid-cols-3 grid-rows-3">
+      {GRID_ARROWS.map(({ dRow, dCol, gridCol, gridRow, arrow }) => {
+        const isActive = activeDirections.has(`${dRow},${dCol}`)
+        return (
+          <div
+            key={`${dRow},${dCol}`}
+            style={{ gridColumn: gridCol, gridRow: gridRow }}
+            className={[
+              'flex items-center justify-center text-[0.55rem] font-black leading-none',
+              isActive ? 'text-yellow-500 opacity-90' : 'opacity-0',
+            ].join(' ')}
+          >
+            {arrow}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/Controls/ControlBar.tsx
+++ b/src/components/Controls/ControlBar.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import type { Player } from '@/lib/shogi/types'
+
+interface ControlBarProps {
+  currentPlayer: Player
+  canUndo: boolean
+  canRedo: boolean
+  onUndo: () => void
+  onRedo: () => void
+  onMenu: () => void
+}
+
+export function ControlBar({
+  currentPlayer,
+  canUndo,
+  canRedo,
+  onUndo,
+  onRedo,
+  onMenu,
+}: ControlBarProps) {
+  const isSente = currentPlayer === 'sente'
+
+  return (
+    <div className="flex h-full w-full items-center justify-between gap-2 px-2">
+      {/* もどるボタン */}
+      <button
+        className={[
+          'flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg px-3 text-sm font-bold transition-colors',
+          canUndo
+            ? 'bg-amber-100 text-amber-900 hover:bg-amber-200'
+            : 'cursor-not-allowed bg-stone-100 text-stone-400',
+        ].join(' ')}
+        onClick={onUndo}
+        disabled={!canUndo}
+        aria-label="もどる"
+      >
+        ◀ もどる
+      </button>
+
+      {/* 手番表示 */}
+      <div
+        className={[
+          'flex flex-1 items-center justify-center rounded-lg px-2 py-1 text-sm font-bold',
+          isSente
+            ? 'bg-blue-100 text-blue-900'
+            : 'bg-red-100 text-red-900',
+        ].join(' ')}
+      >
+        あなたのばんだよ！
+      </div>
+
+      {/* すすむボタン */}
+      <button
+        className={[
+          'flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg px-3 text-sm font-bold transition-colors',
+          canRedo
+            ? 'bg-amber-100 text-amber-900 hover:bg-amber-200'
+            : 'cursor-not-allowed bg-stone-100 text-stone-400',
+        ].join(' ')}
+        onClick={onRedo}
+        disabled={!canRedo}
+        aria-label="すすむ"
+      >
+        すすむ ▶
+      </button>
+
+      {/* メニューボタン */}
+      <button
+        className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg bg-stone-200 px-3 text-sm font-bold text-stone-700 hover:bg-stone-300"
+        onClick={onMenu}
+        aria-label="メニュー"
+      >
+        ☰
+      </button>
+    </div>
+  )
+}

--- a/src/components/Controls/index.ts
+++ b/src/components/Controls/index.ts
@@ -1,0 +1,1 @@
+export { ControlBar } from './ControlBar'


### PR DESCRIPTION
## Summary
- `MoveArrows`: 選択駒の移動方向を 3x3 グリッド矢印（↖↑↗←→↙↓↘）で表示。`MOVE_PATTERNS` から steps/slides を取得し、`Math.sign` で正規化して 8 方向にマッピング。桂馬の跳び（dRow=-2）は ↖/↗ として近似表示
- `ControlBar`: もどる/すすむボタン（disabled 状態連動）・手番表示（先手=青系/後手=赤系）・メニューボタン。全ボタン `min-h-[44px]` 確保
- `Board.tsx`: 選択中マスに `MoveArrows` を `absolute inset-0` で重ねて表示
- `page.tsx`: ControlBar 追加、`undo` / `redo` / `toggleMenu` をストアから接続

## 設計上の決定事項
- **桂馬の近似表示**: 正確な L 字跳びを 3x3 グリッドで表現するのは複雑なため、`Math.sign` で clamping して ↖/↗ として表示。正確な到達マスは合法手の緑ハイライトで補完する方針
- **矢印はマス内に収める**: `absolute inset-0` + `pointer-events-none` でマス内オーバーレイとして実装。overflow を生じさせない

## Test plan
- [ ] 歩を選択すると ↑ のみ表示されること
- [ ] 飛車を選択すると ↑↓←→ が表示されること
- [ ] 王を選択すると 8 方向全て表示されること
- [ ] 桂馬を選択すると ↖↗ が表示されること
- [ ] 「もどる」が履歴なし時に disabled になること
- [ ] 「すすむ」が Redo なし時に disabled になること
- [ ] 手番表示が先手=青/後手=赤で切り替わること

🤖 Generated with [Claude Code](https://claude.com/claude-code)