### PR TITLE
feat: タイトル画面（TitleScreen）を実装 (#17)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,15 +5,18 @@ import { CapturedPieces } from '@/components/CapturedPieces'
 import { ControlBar } from '@/components/Controls'
 import { PromotionDialog, ForcedPromotionToast, GameOverDialog, MenuDialog } from '@/components/Dialogs'
 import { CheckBanner } from '@/components/Notifications'
+import { TitleScreen } from '@/components/TitleScreen'
 import { useGameStore } from '@/stores/gameStore'
 import type { BoardMove, Player, Position, PieceType } from '@/lib/shogi/types'
 import { getPieceAt } from '@/lib/shogi/board'
 
 export default function Home() {
   const {
+    appState,
     gameState,
     ui,
     startNewGame,
+    resumeGame,
     selectPiece,
     selectCapturedPiece,
     deselectPiece,
@@ -41,6 +44,20 @@ export default function Home() {
     winner,
     gameOverReason,
   } = gameState
+
+  // 保存データの有無: 手の履歴が1手以上あれば続きがある
+  const hasSavedGame = gameState.moveHistory.moves.length > 0
+
+  // タイトル画面
+  if (appState === 'title') {
+    return (
+      <TitleScreen
+        hasSavedGame={hasSavedGame}
+        onStartNew={startNewGame}
+        onResume={resumeGame}
+      />
+    )
+  }
 
   const opponent: Player = currentPlayer === 'sente' ? 'gote' : 'sente'
   const lastMove =
@@ -85,7 +102,7 @@ export default function Home() {
   }
 
   return (
-    <main className="relative flex min-h-screen flex-col items-center justify-center gap-2 bg-stone-100 p-4">
+    <main className="relative flex min-h-screen flex-col items-center justify-center gap-2 bg-amber-50 p-4">
       {/* メニューダイアログ */}
       <MenuDialog
         isOpen={ui.isMenuOpen}
@@ -121,15 +138,6 @@ export default function Home() {
         pieceType={ui.forcedPromotionPiece}
         onDismiss={clearForcedPromotion}
       />
-
-      <h1 className="text-2xl font-bold text-amber-900">しょうぎゅー！</h1>
-
-      <button
-        className="rounded-lg bg-amber-700 px-6 py-2 font-semibold text-white hover:bg-amber-800"
-        onClick={startNewGame}
-      >
-        あそぶ！
-      </button>
 
       <div className="flex w-[min(65svh,90svw)] flex-col gap-1">
         {/* 相手の持ち駒エリア（上） */}

--- a/src/components/TitleScreen/TitleScreen.tsx
+++ b/src/components/TitleScreen/TitleScreen.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+interface TitleScreenProps {
+  hasSavedGame: boolean
+  onStartNew: () => void
+  onResume: () => void
+}
+
+// キービジュアル用の動物絵文字（#20 で SVG に置き換え予定）
+const ANIMAL_EMOJIS = ['🦁', '🦅', '🦉', '🐘', '🐺', '🐰', '🐗', '🐤', '🐔']
+
+export function TitleScreen({ hasSavedGame, onStartNew, onResume }: TitleScreenProps) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-8 bg-amber-50 p-8">
+      {/* キービジュアル */}
+      <motion.div
+        className="flex flex-wrap justify-center gap-3 text-5xl"
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        {ANIMAL_EMOJIS.map((emoji, i) => (
+          <motion.span
+            key={i}
+            initial={{ opacity: 0, scale: 0.5 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ delay: i * 0.05, type: 'spring', stiffness: 300 }}
+          >
+            {emoji}
+          </motion.span>
+        ))}
+      </motion.div>
+
+      {/* タイトルロゴ */}
+      <motion.h1
+        className="text-5xl font-black text-amber-800 drop-shadow-sm"
+        initial={{ opacity: 0, scale: 0.8 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ delay: 0.3, type: 'spring', stiffness: 200 }}
+      >
+        しょうぎゅー！
+      </motion.h1>
+
+      {/* ボタン */}
+      <motion.div
+        className="flex flex-col gap-4 w-64"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.5 }}
+      >
+        <button
+          className="rounded-2xl bg-amber-500 py-5 text-xl font-bold text-white shadow-lg hover:bg-amber-600 active:scale-95 transition-transform"
+          onClick={onStartNew}
+        >
+          あそぶ！
+        </button>
+
+        {hasSavedGame && (
+          <button
+            className="rounded-2xl bg-white border-2 border-amber-400 py-4 text-lg font-semibold text-amber-700 shadow hover:bg-amber-50 active:scale-95 transition-transform"
+            onClick={onResume}
+          >
+            つづきから
+          </button>
+        )}
+      </motion.div>
+    </main>
+  )
+}

--- a/src/components/TitleScreen/index.ts
+++ b/src/components/TitleScreen/index.ts
@@ -1,0 +1,1 @@
+export { TitleScreen } from './TitleScreen'


### PR DESCRIPTION
## Summary
- `src/components/TitleScreen/TitleScreen.tsx` を新規作成
  - アプリタイトル「しょうぎゅー！」ロゴ
  - 動物絵文字キービジュアル（#20 で SVG に置き換え予定）
  - 「あそぶ！」ボタン → `startNewGame()`
  - 「つづきから」ボタン → `resumeGame()`（手の履歴がある場合のみ表示）
  - Framer Motion でアニメーション付き表示
- `page.tsx` で `appState === 'title'` の時に `TitleScreen` を表示するよう分岐を追加
- 仮の「あそぶ！」ボタンを削除（タイトル画面に移行）

## Test plan
- [ ] 初回起動時にタイトル画面が表示されること
- [ ] 「あそぶ！」タップで対局画面に遷移すること
- [ ] 手の履歴がない状態では「つづきから」が非表示であること
- [ ] 対局中に `goToTitle()` を呼ぶとタイトル画面に戻ること
- [ ] 「つづきから」タップで盤面が復元されること

closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)