### PR TITLE
feat: ゲームフロー統合 - turn_switching フェーズを自動完了 (#18)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect } from 'react'
 import { Board } from '@/components/Board'
 import { CapturedPieces } from '@/components/CapturedPieces'
 import { ControlBar } from '@/components/Controls'
@@ -31,6 +32,7 @@ export default function Home() {
     resetGame,
     goToTitle,
     resign,
+    completeTurnSwitch,
   } = useGameStore()
   const {
     board,
@@ -44,6 +46,14 @@ export default function Home() {
     winner,
     gameOverReason,
   } = gameState
+
+  // turn_switching フェーズ完了を自動でトリガー
+  // (#19 手番交代アニメーション実装後はアニメーション完了コールバックに置き換える)
+  useEffect(() => {
+    if (phase === 'turn_switching') {
+      completeTurnSwitch()
+    }
+  }, [phase, completeTurnSwitch])
 
   // 保存データの有無: 手の履歴が1手以上あれば続きがある
   const hasSavedGame = gameState.moveHistory.moves.length > 0


### PR DESCRIPTION
## Summary
- `page.tsx` に `useEffect` を追加し、`phase === 'turn_switching'` 時に `completeTurnSwitch()` を自動呼び出し
- これにより駒を動かした後の手番交代が正常に機能するようになる
- コメントで「#19 のアニメーション実装後に差し替えポイント」を明示

## Test plan
- [ ] タイトル画面から「あそぶ！」で対局開始できること
- [ ] 駒を選択 → 移動先タップで駒が動き、手番が切り替わること
- [ ] 持ち駒から駒を選択 → 打てるマスにタップで打てること
- [ ] 成り条件を満たした時にダイアログが表示されること
- [ ] 詰みで勝敗ダイアログが表示されること
- [ ] 王手で CheckBanner が表示されること
- [ ] メニュー → 投了 → 勝敗ダイアログが表示されること
- [ ] 「もういっかい」で盤面リセット、「おわる」でタイトル画面に戻ること

closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)