### PR TITLE
feat: PWAセットアップ（オフライン・ホーム画面追加）（#22）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# PWA (Serwist によるビルド生成物)
+/public/sw.js
+/public/sw.js.map

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next'
+import withSerwist from '@serwist/next'
 
-const nextConfig: NextConfig = {
-  /* config options here */
-};
+const nextConfig: NextConfig = {}
 
-export default nextConfig;
+export default withSerwist({
+  swSrc: 'src/app/sw.ts',
+  swDest: 'public/sw.js',
+  // 開発中はSWを無効化（キャッシュによる開発の妨害を防ぐ）
+  disable: process.env.NODE_ENV === 'development',
+})(nextConfig)

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
+    "dev": "next dev --webpack",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint",
     "test": "vitest",

--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -1,0 +1,27 @@
+import { ImageResponse } from 'next/og'
+
+export const size = { width: 180, height: 180 }
+export const contentType = 'image/png'
+
+// Apple Touch Icon（#20 SVGアセット完成まで暫定）
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#b45309',
+          borderRadius: '32px',
+          fontSize: '112px',
+        }}
+      >
+        🦁
+      </div>
+    ),
+    size,
+  )
+}

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,0 +1,27 @@
+import { ImageResponse } from 'next/og'
+
+export const size = { width: 192, height: 192 }
+export const contentType = 'image/png'
+
+// アプリアイコン（#20 SVGアセット完成まで暫定: ライオン絵文字 + amber背景）
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#b45309',
+          borderRadius: '32px',
+          fontSize: '120px',
+        }}
+      >
+        🦁
+      </div>
+    ),
+    size,
+  )
+}

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from 'next'
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'しょうぎゅー！',
+    short_name: 'しょうぎゅー！',
+    description: '親子で楽しむ将棋アプリ',
+    start_url: '/',
+    display: 'standalone',
+    orientation: 'landscape',
+    background_color: '#fffbeb',
+    theme_color: '#b45309',
+    icons: [
+      {
+        src: '/icon',
+        sizes: '192x192',
+        type: 'image/png',
+      },
+      {
+        src: '/icon?size=512',
+        sizes: '512x512',
+        type: 'image/png',
+      },
+    ],
+  }
+}

--- a/src/app/sw.ts
+++ b/src/app/sw.ts
@@ -1,0 +1,23 @@
+/// <reference lib="webworker" />
+import { defaultCache } from '@serwist/next/worker'
+import type { PrecacheEntry, SerwistGlobalConfig } from 'serwist'
+import { Serwist } from 'serwist'
+
+declare const self: ServiceWorkerGlobalScope & {
+  __SW_MANIFEST: (PrecacheEntry | string)[] | undefined
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface WorkerGlobalScope extends SerwistGlobalConfig {}
+}
+
+const serwist = new Serwist({
+  precacheEntries: self.__SW_MANIFEST,
+  skipWaiting: true,
+  clientsClaim: true,
+  navigationPreload: true,
+  runtimeCaching: defaultCache,
+})
+
+serwist.addEventListeners()


### PR DESCRIPTION
## Summary
- Serwist Service Worker でページをプリキャッシュ → オフライン動作
- Web App Manifest（standalone・landscape・amber テーマカラー）
- Next.js ImageResponse でアプリアイコン生成（暫定: ライオン絵文字、#20 で置換予定）
- `package.json` の `build`/`dev` に `--webpack` フラグ追加（@serwist/next は Turbopack 非対応）
- 開発中は SW を無効化（`disable: process.env.NODE_ENV === 'development'`）
- `public/sw.js` を `.gitignore` に追加（ビルド生成物）

## Test plan
- [ ] Safari の「ホーム画面に追加」でインストールできること
- [ ] ホーム画面から起動するとスタンドアロン表示（ステータスバー非表示）になること
- [ ] オフライン状態でも対局できること

## Related Issue
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)