### PR TITLE
fix: 駒の向きを所有者基準で固定（#52）

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -115,7 +115,7 @@ export function Board({
                   <Piece
                     piece={piece}
                     isSelected={isSelected}
-                    isOpponent={piece.owner !== currentPlayer}
+                    isOpponent={piece.owner === 'gote'}
                   />
                 )}
                 {isSelected && piece && <MoveArrows piece={piece} />}


### PR DESCRIPTION
## Summary
- `isOpponent={piece.owner !== currentPlayer}` → `isOpponent={piece.owner === 'gote'}` に変更
- 盤面固定（#48）後も手番ベースの判定が残っており、手番交代のたびに全駒が反転していた
- 先手の駒は常に 0°、後手の駒は常に 180° で固定

## Test plan
- [ ] 先手で駒を動かした後、先手の駒の向きが変わらないこと
- [ ] 後手の駒は常に上向き（180度回転）であること

## Related Issue
Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)