### PR TITLE
feat: ビジュアルポリッシュ（Zen Maru Gothic + 木目テクスチャ）

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,12 @@
 import type { Metadata, Viewport } from 'next'
-import { Geist } from 'next/font/google'
+import { Zen_Maru_Gothic } from 'next/font/google'
 import './globals.css'
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
+// 子ども向け丸ゴシック（日本語対応）
+const zenMaruGothic = Zen_Maru_Gothic({
+  weight: ['400', '700', '900'],
   subsets: ['latin'],
+  display: 'swap',
 })
 
 export const metadata: Metadata = {
@@ -27,7 +29,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body className={`${geistSans.variable} antialiased`}>{children}</body>
+      <body className={`${zenMaruGothic.className} antialiased`}>{children}</body>
     </html>
   )
 }

--- a/src/components/Board/Square.tsx
+++ b/src/components/Board/Square.tsx
@@ -21,14 +21,26 @@ export function Square({
   isLastMoveTo,
   onClick,
 }: SquareProps) {
-  let bgClass = 'bg-amber-200'
-  if (isSelected) bgClass = 'bg-sky-300'
-  else if (isLastMoveTo) bgClass = 'bg-yellow-300'
-  else if (isLastMoveFrom) bgClass = 'bg-yellow-200'
+  // 木目テクスチャ: 斜めグラデーションで板目を表現
+  const woodGrain = [
+    'linear-gradient(105deg, transparent 40%, rgba(139,90,43,0.07) 40%, rgba(139,90,43,0.07) 42%, transparent 42%)',
+    'linear-gradient(105deg, transparent 60%, rgba(139,90,43,0.05) 60%, rgba(139,90,43,0.05) 61%, transparent 61%)',
+    'linear-gradient(to bottom, rgba(255,220,150,0.3) 0%, transparent 60%)',
+  ].join(', ')
+
+  let bgColor = ''
+  if (isSelected) bgColor = '#7dd3fc'
+  else if (isLastMoveTo) bgColor = '#fde047'
+  else if (isLastMoveFrom) bgColor = '#fef08a'
+
+  const bgStyle = bgColor
+    ? { backgroundColor: bgColor }
+    : { backgroundImage: `${woodGrain}, linear-gradient(to bottom right, #d4a843, #c49132)`, backgroundColor: '#d4a843' }
 
   return (
     <div
-      className={`relative flex aspect-square items-center justify-center border-r border-b border-amber-900/50 cursor-pointer select-none ${bgClass}`}
+      className="relative flex aspect-square items-center justify-center border-r border-b border-amber-900/50 cursor-pointer select-none"
+      style={bgStyle}
       onClick={onClick}
     >
       {/* 取れる駒ハイライト（赤） */}


### PR DESCRIPTION
## Summary
- フォントを Zen Maru Gothic に変更（子ども向け丸ゴシック、400/700/900 weight）
- 将棋盤マスに CSS グラデーションで木目テクスチャを追加
- 選択・最終手ハイライトは従来通り色変更で表示

## Test plan
- [ ] 盤面マスに木目模様が表示される
- [ ] 駒選択時に水色ハイライトが表示される
- [ ] 最終手の移動元・移動先が黄色ハイライトで表示される
- [ ] フォントが丸ゴシックで表示される

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)