### PR TITLE
fix: 歩・香・桂が敵陣最奥に移動できないバグ修正 (#78)

### DIFF
--- a/src/lib/shogi/__tests__/moves.test.ts
+++ b/src/lib/shogi/__tests__/moves.test.ts
@@ -59,10 +59,10 @@ describe('香車 (lance) の移動', () => {
     board[0][4] = { type: 'king', owner: 'gote' }
     const captured = createInitialCapturedPieces()
     const moves = getLegalMoves(board, { row: 6, col: 0 }, captured, 'sente')
-    // row5, row4, row3, row2, row1 に移動可能（row0は行き所なし）
-    expect(moves.length).toBe(5)
+    // row5, row4, row3, row2, row1, row0 に移動可能（row0は強制成り）
+    expect(moves.length).toBe(6)
     expect(moves.some(m => m.row === 5 && m.col === 0)).toBe(true)
-    expect(moves.some(m => m.row === 1 && m.col === 0)).toBe(true)
+    expect(moves.some(m => m.row === 0 && m.col === 0)).toBe(true)
   })
 
   it('先手の香車は途中に味方駒があるとブロックされる', () => {

--- a/src/lib/shogi/moves.ts
+++ b/src/lib/shogi/moves.ts
@@ -209,9 +209,6 @@ export function getLegalMoves(
   const candidates = generateMoveCandidates(board, pos)
 
   return candidates.filter(target => {
-    // 行き所のない駒チェック
-    if (isNowhereToGo(piece.type, currentPlayer, target)) return false
-
     // 王手放置チェック: 仮に移動した盤面で自玉に王手がかかるか
     const next = setPieceAt(removePieceAt(board, pos), target, piece)
     if (isInCheck(next, currentPlayer)) return false


### PR DESCRIPTION
## 原因

`getLegalMoves`（盤上の移動の合法手生成）内で `isNowhereToGo` チェックが誤適用されていた。

このチェックは **持ち駒を打つ（DROP）場合のみ** 適用すべきルール：
- 一段目に歩・香を打てない
- 一・二段目に桂を打てない

盤上の移動では、これらの位置へ到達しても**強制成り**で対応できるため、移動自体は合法。

## 修正内容

- `getLegalMoves` から `isNowhereToGo` チェックを削除
- `getLegalDrops` のみに残す（元々正しかった）
- テストの期待値を実際のルールに合わせて修正（香車が一段目に移動可能）

## 影響する不具合

- 歩が一段目の敵駒を取れない（例: 6二の歩が6一の金を取れない）
- 桂が一・二段目に移動できない（Issue #78 の操作不能バグと同根）

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)