### PR TITLE
feat: 駒の移動アニメーション（#61）

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import { PromotionDialog, ForcedPromotionToast, GameOverDialog, MenuDialog } fro
 import { CheckBanner } from '@/components/Notifications'
 import { TitleScreen } from '@/components/TitleScreen'
 import { useGameStore } from '@/stores/gameStore'
-import type { BoardMove, Player, Position, PieceType } from '@/lib/shogi/types'
+import type { BoardMove, Position, PieceType } from '@/lib/shogi/types'
 import { getPieceAt } from '@/lib/shogi/board'
 
 export default function Home() {
@@ -34,6 +34,7 @@ export default function Home() {
     goToTitle,
     resign,
     completeTurnSwitch,
+    completeMoveAnimation,
   } = useGameStore()
   const {
     board,
@@ -70,7 +71,6 @@ export default function Home() {
     )
   }
 
-  const opponent: Player = currentPlayer === 'sente' ? 'gote' : 'sente'
   const lastMove =
     moveHistory.currentIndex >= 0 ? moveHistory.moves[moveHistory.currentIndex] : null
 
@@ -170,6 +170,8 @@ export default function Home() {
           legalMoves={legalMoves}
           lastMove={lastMove}
           onSquareClick={handleSquareClick}
+          animatingMove={ui.animatingMove}
+          onAnimationComplete={completeMoveAnimation}
         />
 
         {/* 先手の持ち駒エリア（下・固定） */}

--- a/src/components/Board/AnimatingPiece.tsx
+++ b/src/components/Board/AnimatingPiece.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useState, useLayoutEffect } from 'react'
+import { motion } from 'framer-motion'
+import type { RefObject } from 'react'
+
+type GridRef = RefObject<HTMLDivElement | null>
+import type { AnimatingMoveInfo } from '@/lib/shogi/types'
+import { Piece } from '@/components/Piece'
+
+interface AnimatingPieceProps {
+  animatingMove: AnimatingMoveInfo
+  gridRef: GridRef
+  onComplete: () => void
+}
+
+export function AnimatingPiece({ animatingMove, gridRef, onComplete }: AnimatingPieceProps) {
+  const [squareSize, setSquareSize] = useState<{ w: number; h: number } | null>(null)
+
+  // レンダー後・ブラウザ描画前に同期的にサイズを取得する
+  useLayoutEffect(() => {
+    if (!gridRef.current) return
+    const { width, height } = gridRef.current.getBoundingClientRect()
+    setSquareSize({ w: width / 9, h: height / 9 })
+  }, [gridRef])
+
+  if (!squareSize) return null
+
+  const { piece, from, to, captured } = animatingMove
+  const { w: squareW, h: squareH } = squareSize
+  const pieceW = squareW - 6
+  const pieceH = squareH - 6
+
+  const toX = to.col * squareW + 3
+  const toY = to.row * squareH + 3
+
+  // 持ち駒打ち: 目標マスでポップイン（scale 0 → 1）
+  if (from === null) {
+    return (
+      <motion.div
+        style={{
+          position: 'absolute',
+          left: toX,
+          top: toY,
+          width: pieceW,
+          height: pieceH,
+          pointerEvents: 'none',
+          zIndex: 20,
+        }}
+        initial={{ scale: 0 }}
+        animate={{ scale: 1 }}
+        transition={{ type: 'spring', stiffness: 400, damping: 20 }}
+        onAnimationComplete={onComplete}
+      >
+        <Piece piece={piece} isOpponent={piece.owner === 'gote'} />
+      </motion.div>
+    )
+  }
+
+  // 盤上移動: from → to へスライド
+  const fromX = from.col * squareW + 3
+  const fromY = from.row * squareH + 3
+  const deltaX = toX - fromX
+  const deltaY = toY - fromY
+
+  const isKnight = piece.type === 'knight'
+
+  return (
+    <>
+      {/* 取られる駒: スケール縮小 + フェードアウト */}
+      {captured && (
+        <motion.div
+          style={{
+            position: 'absolute',
+            left: toX,
+            top: toY,
+            width: pieceW,
+            height: pieceH,
+            pointerEvents: 'none',
+            zIndex: 19,
+          }}
+          animate={{ scale: 0.3, opacity: 0 }}
+          transition={{ duration: 0.25 }}
+        >
+          <Piece piece={captured} isOpponent={captured.owner === 'gote'} />
+        </motion.div>
+      )}
+
+      {/* 移動する駒: from → to へアニメーション */}
+      <motion.div
+        style={{
+          position: 'absolute',
+          left: fromX,
+          top: fromY,
+          width: pieceW,
+          height: pieceH,
+          pointerEvents: 'none',
+          zIndex: 20,
+        }}
+        animate={{
+          x: deltaX,
+          // 桂馬: 放物線軌道（弧を描いてぴょんと跳ねる）
+          y: isKnight
+            ? [0, deltaY / 2 - squareH * 0.8, deltaY]
+            : deltaY,
+        }}
+        transition={
+          isKnight
+            ? {
+                x: { duration: 0.35, ease: 'linear' },
+                y: { duration: 0.35, times: [0, 0.45, 1], ease: ['easeOut', 'easeIn'] },
+              }
+            : { type: 'spring', stiffness: 300, damping: 25 }
+        }
+        onAnimationComplete={onComplete}
+      >
+        <Piece piece={piece} isOpponent={piece.owner === 'gote'} />
+      </motion.div>
+    </>
+  )
+}

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import type { Board as BoardType, Move, Player, Position } from '@/lib/shogi/types'
+import { useRef } from 'react'
+import type { AnimatingMoveInfo, Board as BoardType, Move, Player, Position } from '@/lib/shogi/types'
 import { Square } from './Square'
 import { Piece } from '@/components/Piece'
 import { MoveArrows } from './MoveArrows'
+import { AnimatingPiece } from './AnimatingPiece'
 
 // ============================================================
 // 定数
@@ -44,6 +46,8 @@ interface BoardProps {
   legalMoves: Position[]
   lastMove: Move | null
   onSquareClick: (pos: Position) => void
+  animatingMove: AnimatingMoveInfo | null
+  onAnimationComplete: () => void
 }
 
 // ============================================================
@@ -57,7 +61,11 @@ export function Board({
   legalMoves,
   lastMove,
   onSquareClick,
+  animatingMove,
+  onAnimationComplete,
 }: BoardProps) {
+  const gridRef = useRef<HTMLDivElement>(null)
+
   // Set に変換しておくことでO(1)ルックアップを実現
   const legalMoveSet = new Set(legalMoves.map((p) => `${p.row},${p.col}`))
 
@@ -80,50 +88,67 @@ export function Board({
 
       <div className="flex">
         {/* 9x9 盤面グリッド */}
-        <div className="grid flex-1 grid-cols-9 border-l-2 border-t-2 border-amber-900">
-          {Array.from({ length: 81 }, (_, i) => {
-            const displayRow = Math.floor(i / 9)
-            const displayCol = i % 9
-            const internalPos = toInternalPos(displayRow, displayCol)
-            const posKey = `${internalPos.row},${internalPos.col}`
+        <div className="relative flex-1">
+          <div ref={gridRef} className="grid grid-cols-9 border-l-2 border-t-2 border-amber-900">
+            {Array.from({ length: 81 }, (_, i) => {
+              const displayRow = Math.floor(i / 9)
+              const displayCol = i % 9
+              const internalPos = toInternalPos(displayRow, displayCol)
+              const posKey = `${internalPos.row},${internalPos.col}`
 
-            const piece = board[internalPos.row][internalPos.col]
-            const isSelected =
-              selectedPosition?.row === internalPos.row &&
-              selectedPosition?.col === internalPos.col
-            const isLegalMove = legalMoveSet.has(posKey)
-            const isCapturable =
-              isLegalMove && piece !== null && piece.owner !== currentPlayer
-            const isLastMoveFrom =
-              lastMoveFrom?.row === internalPos.row &&
-              lastMoveFrom?.col === internalPos.col
-            const isLastMoveTo =
-              lastMoveTo?.row === internalPos.row &&
-              lastMoveTo?.col === internalPos.col
+              const piece = board[internalPos.row][internalPos.col]
+              const isSelected =
+                selectedPosition?.row === internalPos.row &&
+                selectedPosition?.col === internalPos.col
+              const isLegalMove = legalMoveSet.has(posKey)
+              const isCapturable =
+                isLegalMove && piece !== null && piece.owner !== currentPlayer
+              const isLastMoveFrom =
+                lastMoveFrom?.row === internalPos.row &&
+                lastMoveFrom?.col === internalPos.col
+              const isLastMoveTo =
+                lastMoveTo?.row === internalPos.row &&
+                lastMoveTo?.col === internalPos.col
 
-            return (
-              <Square
-                key={posKey}
-                isSelected={isSelected}
-                isLegalMove={isLegalMove}
-                isCapturable={isCapturable}
-                isLastMoveFrom={isLastMoveFrom}
-                isLastMoveTo={isLastMoveTo}
-                onClick={() => onSquareClick(internalPos)}
-              >
-                {piece && (
-                  <div className="absolute inset-[3px]">
-                    <Piece
-                      piece={piece}
-                      isSelected={isSelected}
-                      isOpponent={piece.owner === 'gote'}
-                    />
-                  </div>
-                )}
-                {isSelected && piece && <MoveArrows piece={piece} />}
-              </Square>
-            )
-          })}
+              // アニメーション中は移動先マスの駒を非表示（AnimatingPiece が代わりに表示）
+              const isAnimatingTarget =
+                animatingMove !== null &&
+                animatingMove.to.row === internalPos.row &&
+                animatingMove.to.col === internalPos.col
+
+              return (
+                <Square
+                  key={posKey}
+                  isSelected={isSelected}
+                  isLegalMove={isLegalMove}
+                  isCapturable={isCapturable}
+                  isLastMoveFrom={isLastMoveFrom}
+                  isLastMoveTo={isLastMoveTo}
+                  onClick={() => onSquareClick(internalPos)}
+                >
+                  {piece && !isAnimatingTarget && (
+                    <div className="absolute inset-[3px]">
+                      <Piece
+                        piece={piece}
+                        isSelected={isSelected}
+                        isOpponent={piece.owner === 'gote'}
+                      />
+                    </div>
+                  )}
+                  {isSelected && piece && <MoveArrows piece={piece} />}
+                </Square>
+              )
+            })}
+          </div>
+
+          {/* 移動アニメーション overlay */}
+          {animatingMove && (
+            <AnimatingPiece
+              animatingMove={animatingMove}
+              gridRef={gridRef}
+              onComplete={onAnimationComplete}
+            />
+          )}
         </div>
 
         {/* 段ラベル（一〜九 または 九〜一） */}

--- a/src/lib/shogi/types.ts
+++ b/src/lib/shogi/types.ts
@@ -102,6 +102,16 @@ export interface GameState {
   gameOverReason: 'checkmate' | 'resign' | null
 }
 
+export interface AnimatingMoveInfo {
+  piece: Piece
+  from: Position | null  // null = 持ち駒打ち
+  to: Position
+  captured: Piece | null
+  pendingPhase: 'turn_switching' | 'promotion_check'
+  promote: boolean
+  isForcedPromote: boolean
+}
+
 export interface UIState {
   isMenuOpen: boolean
   isAnimating: boolean
@@ -109,6 +119,8 @@ export interface UIState {
   forcedPromotionPiece: PieceType | null
   /** 効果音ミュート */
   isMuted: boolean
+  /** 移動アニメーション中の情報（null = アニメーションなし） */
+  animatingMove: AnimatingMoveInfo | null
 }
 
 // ============================================================

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import type { GameState, PieceType, Player, Position, UIState } from '../lib/shogi/types'
+import type { AnimatingMoveInfo, GameState, PieceType, Player, Position, UIState } from '../lib/shogi/types'
 import { getLegalMoves, getLegalDrops, isInCheck } from '../lib/shogi/moves'
 import { isCheckmate, canPromote, mustPromote } from '../lib/shogi/rules'
 import { executeMove, executeDrop, undoMove, redoMove, createInitialGameState } from '../lib/shogi/game'
@@ -36,6 +36,7 @@ interface GameStore {
   completeTurnSwitch: () => void
   completeCheckNotify: () => void
   clearForcedPromotion: () => void
+  completeMoveAnimation: () => void
 }
 
 // ============================================================
@@ -47,6 +48,7 @@ const INITIAL_UI_STATE: UIState = {
   isAnimating: false,
   forcedPromotionPiece: null,
   isMuted: false,
+  animatingMove: null,
 }
 
 // ============================================================
@@ -172,47 +174,41 @@ export const useGameStore = create<GameStore>()(
         if (!piece) return
 
         const from = selectedPosition
-
-        // 強制成りチェック
-        if (mustPromote(piece, to)) {
-          // 強制成り: 成りで実行して手番交代へ
-          const nextState = executeMove(gameState, from, to, true)
-          playSound('forced_promote')
-          set(state => ({
-            gameState: {
-              ...nextState,
-              phase: 'turn_switching',
-            },
-            ui: { ...state.ui, forcedPromotionPiece: piece.type as PieceType },
-          }))
-          return
-        }
-
-        // 捕獲の有無で音を分ける
         const captured = getPieceAt(board, to)
-        playSound(captured ? 'capture' : 'place')
 
-        // 任意成りチェック
-        if (canPromote(piece, from, to)) {
-          // 成り選択のためにまず非成りで手を実行して履歴に追加
-          const nextState = executeMove(gameState, from, to, false)
-          set({
-            gameState: {
-              ...nextState,
-              phase: 'promotion_check',
-            },
-          })
-          return
+        // 成り・手番遷移先を決定
+        let promote = false
+        let isForcedPromote = false
+        let pendingPhase: AnimatingMoveInfo['pendingPhase'] = 'turn_switching'
+
+        if (mustPromote(piece, to)) {
+          promote = true
+          isForcedPromote = true
+          pendingPhase = 'turn_switching'
+          playSound('forced_promote')
+        } else if (canPromote(piece, from, to)) {
+          promote = false
+          pendingPhase = 'promotion_check'
+          playSound(captured ? 'capture' : 'place')
+        } else {
+          promote = false
+          pendingPhase = 'turn_switching'
+          playSound(captured ? 'capture' : 'place')
         }
 
-        // 成りなし: 手番交代へ
-        const nextState = executeMove(gameState, from, to, false)
-        set({
+        // 移動を実行（盤面を即時更新）
+        const nextState = executeMove(gameState, from, to, promote)
+
+        set(state => ({
           gameState: {
             ...nextState,
-            phase: 'turn_switching',
+            phase: 'moving',
           },
-        })
+          ui: {
+            ...state.ui,
+            animatingMove: { piece, from, to, captured, pendingPhase, promote, isForcedPromote },
+          },
+        }))
       },
 
       // ============================================================
@@ -221,7 +217,7 @@ export const useGameStore = create<GameStore>()(
 
       dropPiece: (to: Position) => {
         const { gameState } = get()
-        const { phase, selectedCaptured, legalMoves } = gameState
+        const { phase, selectedCaptured, legalMoves, currentPlayer } = gameState
 
         if (phase !== 'captured_selected' || !selectedCaptured) return
 
@@ -231,12 +227,25 @@ export const useGameStore = create<GameStore>()(
 
         const nextState = executeDrop(gameState, selectedCaptured, to)
         playSound('drop')
-        set({
+
+        set(state => ({
           gameState: {
             ...nextState,
-            phase: 'turn_switching',
+            phase: 'moving',
           },
-        })
+          ui: {
+            ...state.ui,
+            animatingMove: {
+              piece: { type: selectedCaptured, owner: currentPlayer },
+              from: null,
+              to,
+              captured: null,
+              pendingPhase: 'turn_switching',
+              promote: false,
+              isForcedPromote: false,
+            },
+          },
+        }))
       },
 
       // ============================================================
@@ -439,6 +448,29 @@ export const useGameStore = create<GameStore>()(
         soundEngine.setMuted(nextMuted)
         set(state => ({
           ui: { ...state.ui, isMuted: nextMuted },
+        }))
+      },
+
+      // ============================================================
+      // 移動アニメーション完了
+      // ============================================================
+
+      completeMoveAnimation: () => {
+        const { ui } = get()
+        if (!ui.animatingMove) return
+
+        const { pendingPhase, isForcedPromote, piece } = ui.animatingMove
+
+        set(state => ({
+          gameState: {
+            ...state.gameState,
+            phase: pendingPhase,
+          },
+          ui: {
+            ...state.ui,
+            animatingMove: null,
+            ...(isForcedPromote ? { forcedPromotionPiece: piece.type as PieceType } : {}),
+          },
         }))
       },
     }),


### PR DESCRIPTION
## Summary

- 盤上の駒移動を Framer Motion spring でスライドアニメーション化
- 桂馬のみ Y 方向 keyframes で放物線軌道（ぴょんと跳ねる）
- 駒を取る際、取られる駒が scale + opacity でフェードアウト
- 持ち駒打ちは打ち位置でポップイン（scale 0→1）
- `phase: 'moving'` 中は全操作を無効化（アニメーション完了後に次フェーズへ遷移）
- Undo/Redo 時はアニメーションなし（即時反映）

## 主な変更

| ファイル | 変更内容 |
|---------|---------|
| `types.ts` | `UIState` に `AnimatingMoveInfo` / `animatingMove` を追加 |
| `gameStore.ts` | `movePiece`/`dropPiece` でアニメーション開始、`completeMoveAnimation()` 追加 |
| `Board/AnimatingPiece.tsx` | 新規: 絶対配置で駒を Framer Motion アニメーション |
| `Board/Board.tsx` | gridRef 追加、アニメーション中は移動先マスの駒を非表示 |
| `page.tsx` | `completeMoveAnimation` を Board に接続 |

## Test plan

- [x] 通常移動がスムーズにスライドする
- [x] 桂馬がアーチ軌道で移動する
- [x] 駒を取る際に相手駒がフェードアウトする
- [x] 持ち駒打ちがポップインする
- [x] アニメーション中はタップ操作が効かない
- [x] Undo/Redo は即時反映（アニメーションなし）
- [x] 王手・詰み判定が正常に動作する

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)