### PR TITLE
feat: 成りの変身アニメーション（#62）

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,6 +35,7 @@ export default function Home() {
     resign,
     completeTurnSwitch,
     completeMoveAnimation,
+    completePromotion,
   } = useGameStore()
   const {
     board,
@@ -172,6 +173,8 @@ export default function Home() {
           onSquareClick={handleSquareClick}
           animatingMove={ui.animatingMove}
           onAnimationComplete={completeMoveAnimation}
+          promotingInfo={ui.promotingInfo}
+          onPromotionComplete={completePromotion}
         />
 
         {/* 先手の持ち駒エリア（下・固定） */}

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { useRef } from 'react'
-import type { AnimatingMoveInfo, Board as BoardType, Move, Player, Position } from '@/lib/shogi/types'
+import { useRef, useState, useLayoutEffect } from 'react'
+import type { AnimatingMoveInfo, Board as BoardType, Move, Player, Position, PromotingInfo } from '@/lib/shogi/types'
 import { Square } from './Square'
 import { Piece } from '@/components/Piece'
 import { MoveArrows } from './MoveArrows'
 import { AnimatingPiece } from './AnimatingPiece'
+import { PromotionEffect } from '@/components/Piece/PromotionEffect'
 
 // ============================================================
 // 定数
@@ -48,6 +49,8 @@ interface BoardProps {
   onSquareClick: (pos: Position) => void
   animatingMove: AnimatingMoveInfo | null
   onAnimationComplete: () => void
+  promotingInfo: PromotingInfo | null
+  onPromotionComplete: () => void
 }
 
 // ============================================================
@@ -63,8 +66,17 @@ export function Board({
   onSquareClick,
   animatingMove,
   onAnimationComplete,
+  promotingInfo,
+  onPromotionComplete,
 }: BoardProps) {
   const gridRef = useRef<HTMLDivElement>(null)
+  const [squareSize, setSquareSize] = useState<{ w: number; h: number } | null>(null)
+
+  useLayoutEffect(() => {
+    if (!gridRef.current) return
+    const { width, height } = gridRef.current.getBoundingClientRect()
+    setSquareSize({ w: width / 9, h: height / 9 })
+  }, [gridRef])
 
   // Set に変換しておくことでO(1)ルックアップを実現
   const legalMoveSet = new Set(legalMoves.map((p) => `${p.row},${p.col}`))
@@ -147,6 +159,16 @@ export function Board({
               animatingMove={animatingMove}
               gridRef={gridRef}
               onComplete={onAnimationComplete}
+            />
+          )}
+
+          {/* 成りアニメーション overlay */}
+          {promotingInfo && squareSize && (
+            <PromotionEffect
+              position={promotingInfo.position}
+              squareSize={squareSize}
+              isForcedPromote={promotingInfo.isForcedPromote}
+              onComplete={onPromotionComplete}
             />
           )}
         </div>

--- a/src/components/Piece/PromotionEffect.tsx
+++ b/src/components/Piece/PromotionEffect.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { useEffect, useMemo } from 'react'
+import { motion } from 'framer-motion'
+import type { Position } from '@/lib/shogi/types'
+
+// ============================================================
+// パーティクル設定
+// ============================================================
+
+const PARTICLE_COUNT = 10
+const PARTICLE_COLORS = ['#F59E0B', '#FCD34D', '#FBBF24', '#F97316', '#FDE68A']
+
+function getParticleProps(index: number, radius: number) {
+  const angle = (index / PARTICLE_COUNT) * 2 * Math.PI
+  const distance = radius * (0.8 + Math.random() * 0.4)
+  return {
+    x: Math.cos(angle) * distance,
+    y: Math.sin(angle) * distance,
+    color: PARTICLE_COLORS[index % PARTICLE_COLORS.length],
+  }
+}
+
+// ============================================================
+// Props
+// ============================================================
+
+interface PromotionEffectProps {
+  position: Position
+  squareSize: { w: number; h: number }
+  isForcedPromote: boolean
+  onComplete: () => void
+}
+
+// ============================================================
+// コンポーネント
+// ============================================================
+
+export function PromotionEffect({
+  position,
+  squareSize,
+  isForcedPromote,
+  onComplete,
+}: PromotionEffectProps) {
+  const { w, h } = squareSize
+  const centerX = position.col * w + w / 2
+  const centerY = position.row * h + h / 2
+  const radius = (w + h) / 4
+
+  // 通常成り: 1.0s、強制成り: 0.5s
+  const duration = isForcedPromote ? 0.5 : 1.0
+  const flashDelay = isForcedPromote ? 0 : 0.3
+  const particleDelay = isForcedPromote ? 0.15 : 0.5
+
+  // アニメーション完了タイマー
+  useEffect(() => {
+    const timer = setTimeout(onComplete, duration * 1000)
+    return () => clearTimeout(timer)
+  }, [duration, onComplete])
+
+  // パーティクルの位置はマウント時に固定（再レンダーで変化しない）
+  const particles = useMemo(
+    () => Array.from({ length: PARTICLE_COUNT }, (_, i) => getParticleProps(i, radius)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        pointerEvents: 'none',
+        zIndex: 30,
+        overflow: 'hidden',
+      }}
+    >
+      {/* 白いフラッシュ */}
+      <motion.div
+        style={{
+          position: 'absolute',
+          left: centerX - w / 2,
+          top: centerY - h / 2,
+          width: w,
+          height: h,
+          borderRadius: '50%',
+          background: 'white',
+        }}
+        initial={{ opacity: 0, scale: 0.5 }}
+        animate={{ opacity: [0, 0.9, 0], scale: [0.5, 1.4, 1.0] }}
+        transition={{
+          delay: flashDelay,
+          duration: isForcedPromote ? 0.3 : 0.2,
+          times: [0, 0.5, 1],
+          ease: 'easeOut',
+        }}
+      />
+
+      {/* 金色のパーティクル */}
+      {particles.map((p, i) => (
+        <motion.div
+          key={i}
+          style={{
+            position: 'absolute',
+            left: centerX - 5,
+            top: centerY - 5,
+            width: 10,
+            height: 10,
+            borderRadius: '50%',
+            background: p.color,
+          }}
+          initial={{ x: 0, y: 0, opacity: 1, scale: 1 }}
+          animate={{
+            x: p.x,
+            y: p.y,
+            opacity: 0,
+            scale: 0.3,
+          }}
+          transition={{
+            delay: particleDelay + i * 0.02,
+            duration: duration - particleDelay,
+            ease: 'easeOut',
+          }}
+        />
+      ))}
+
+      {/* ★バッジポップイン（通常成りのみ） */}
+      {!isForcedPromote && (
+        <motion.div
+          style={{
+            position: 'absolute',
+            left: centerX + w * 0.15,
+            top: centerY - h * 0.5,
+            fontSize: h * 0.3,
+            lineHeight: 1,
+          }}
+          initial={{ scale: 0, rotate: -30 }}
+          animate={{ scale: 1, rotate: 0 }}
+          transition={{
+            delay: 0.55,
+            type: 'spring',
+            stiffness: 500,
+            damping: 18,
+          }}
+        >
+          ⭐
+        </motion.div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/shogi/types.ts
+++ b/src/lib/shogi/types.ts
@@ -79,6 +79,7 @@ export type GamePhase =
   | 'captured_selected'
   | 'moving'
   | 'promotion_check'
+  | 'promoting'
   | 'turn_switching'
   | 'check_notify'
   | 'checkmate'
@@ -112,6 +113,12 @@ export interface AnimatingMoveInfo {
   isForcedPromote: boolean
 }
 
+export interface PromotingInfo {
+  position: Position
+  pieceType: PieceType
+  isForcedPromote: boolean
+}
+
 export interface UIState {
   isMenuOpen: boolean
   isAnimating: boolean
@@ -121,6 +128,8 @@ export interface UIState {
   isMuted: boolean
   /** 移動アニメーション中の情報（null = アニメーションなし） */
   animatingMove: AnimatingMoveInfo | null
+  /** 成りアニメーション中の情報（null = アニメーションなし） */
+  promotingInfo: PromotingInfo | null
 }
 
 // ============================================================

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import type { AnimatingMoveInfo, GameState, PieceType, Player, Position, UIState } from '../lib/shogi/types'
+import type { AnimatingMoveInfo, GameState, PieceType, Player, Position, UIState, PromotingInfo } from '../lib/shogi/types'
 import { getLegalMoves, getLegalDrops, isInCheck } from '../lib/shogi/moves'
 import { isCheckmate, canPromote, mustPromote } from '../lib/shogi/rules'
 import { executeMove, executeDrop, undoMove, redoMove, createInitialGameState } from '../lib/shogi/game'
@@ -37,6 +37,7 @@ interface GameStore {
   completeCheckNotify: () => void
   clearForcedPromotion: () => void
   completeMoveAnimation: () => void
+  completePromotion: () => void
 }
 
 // ============================================================
@@ -49,6 +50,7 @@ const INITIAL_UI_STATE: UIState = {
   forcedPromotionPiece: null,
   isMuted: false,
   animatingMove: null,
+  promotingInfo: null,
 }
 
 // ============================================================
@@ -267,12 +269,21 @@ export const useGameStore = create<GameStore>()(
 
           const reExecuted = executeMove(undone, lastMove.from, lastMove.to, true)
           playSound('promote')
-          set({
+          const promotingInfo: PromotingInfo = {
+            position: lastMove.to,
+            pieceType: lastMove.piece.type as PieceType,
+            isForcedPromote: false,
+          }
+          set(state => ({
             gameState: {
               ...reExecuted,
-              phase: 'turn_switching',
+              phase: 'promoting',
             },
-          })
+            ui: {
+              ...state.ui,
+              promotingInfo,
+            },
+          }))
         } else {
           // 成らない: 既に実行済みの非成り手をそのまま確定
           set(state => ({
@@ -459,17 +470,55 @@ export const useGameStore = create<GameStore>()(
         const { ui } = get()
         if (!ui.animatingMove) return
 
-        const { pendingPhase, isForcedPromote, piece } = ui.animatingMove
+        const { pendingPhase, isForcedPromote, piece, to } = ui.animatingMove
+
+        if (isForcedPromote) {
+          // 強制成り: promoting フェーズを経由してアニメーション再生
+          const promotingInfo: PromotingInfo = {
+            position: to,
+            pieceType: piece.type as PieceType,
+            isForcedPromote: true,
+          }
+          set(state => ({
+            gameState: {
+              ...state.gameState,
+              phase: 'promoting',
+            },
+            ui: {
+              ...state.ui,
+              animatingMove: null,
+              promotingInfo,
+            },
+          }))
+        } else {
+          set(state => ({
+            gameState: {
+              ...state.gameState,
+              phase: pendingPhase,
+            },
+            ui: {
+              ...state.ui,
+              animatingMove: null,
+            },
+          }))
+        }
+      },
+
+      completePromotion: () => {
+        const { ui } = get()
+        if (!ui.promotingInfo) return
+
+        const { isForcedPromote, pieceType } = ui.promotingInfo
 
         set(state => ({
           gameState: {
             ...state.gameState,
-            phase: pendingPhase,
+            phase: 'turn_switching',
           },
           ui: {
             ...state.ui,
-            animatingMove: null,
-            ...(isForcedPromote ? { forcedPromotionPiece: piece.type as PieceType } : {}),
+            promotingInfo: null,
+            ...(isForcedPromote ? { forcedPromotionPiece: pieceType } : {}),
           },
         }))
       },


### PR DESCRIPTION
## Summary

- `GamePhase` に `'promoting'` フェーズを追加し、成り後に変身エフェクトを再生するフローを実装
- `PromotionEffect` コンポーネント新規作成（`src/components/Piece/PromotionEffect.tsx`）
  - 白フラッシュ → 金色パーティクル放射（10個）→ ★バッジポップインの演出
  - 通常成り（1.0s）・強制成り（0.5s 短縮版）に対応
- `UIState` に `promotingInfo` フィールドを追加（成りアニメーション中の位置・駒種を保持）
- `Board` に `PromotionEffect` オーバーレイを追加し、盤上の該当マスでエフェクトが再生される

## State flow

```
promotion_check → (「なる！」) → promoting → turn_switching
moving(強制成り) → promoting → turn_switching
```

## Test plan

- [x] 歩が三段目に入り「なる！」を押すと変身エフェクトが再生される
- [x] エフェクト中（1秒）は操作が無効化される
- [x] エフェクト完了後に手番が正しく交代する
- [x] 強制成り（歩が一段目）で 0.5s の短縮エフェクトが自動再生される
- [x] 強制成りトーストがエフェクト完了後に表示される

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)