### PR TITLE
fix: 盤面3D表示の不具合修正（#83関連）

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -14,10 +14,6 @@ import { PromotionEffect } from '@/components/Piece/PromotionEffect'
 
 const DAN_LABELS = ['一', '二', '三', '四', '五', '六', '七', '八', '九']
 
-// 将棋盤の星マーカー位置（0-indexed row, col）
-// (3,3), (3,6), (6,3), (6,6) の4点
-const STAR_POINTS = new Set(['3,3', '3,6', '6,3', '6,6'])
-
 // ============================================================
 // ヘルパー関数
 // ============================================================
@@ -110,7 +106,7 @@ export function Board({
             className="grid grid-cols-9 border-l-2 border-t-2 border-amber-900"
             style={{
               boxShadow:
-                '2px 2px 0 #7a5c1e, 4px 4px 0 #5a3e0e, 0 6px 16px rgba(0,0,0,0.35), inset 0 0 8px rgba(255,200,80,0.15)',
+                'inset 3px 3px 6px rgba(255,210,80,0.35), inset -3px -3px 6px rgba(0,0,0,0.28), 0 4px 16px rgba(0,0,0,0.3)',
             }}
           >
             {Array.from({ length: 81 }, (_, i) => {
@@ -139,8 +135,6 @@ export function Board({
                 animatingMove.to.row === internalPos.row &&
                 animatingMove.to.col === internalPos.col
 
-              const isStarPoint = STAR_POINTS.has(`${internalPos.row},${internalPos.col}`)
-
               return (
                 <Square
                   key={posKey}
@@ -149,7 +143,6 @@ export function Board({
                   isCapturable={isCapturable}
                   isLastMoveFrom={isLastMoveFrom}
                   isLastMoveTo={isLastMoveTo}
-                  isStarPoint={isStarPoint}
                   onClick={() => onSquareClick(internalPos)}
                 >
                   {piece && !isAnimatingTarget && (
@@ -188,7 +181,7 @@ export function Board({
         </div>
 
         {/* 段ラベル（一〜九 または 九〜一） */}
-        <div className="flex w-6 flex-col border-t-2 border-amber-900">
+        <div className="flex w-6 flex-col">
           {Array.from({ length: 9 }, (_, displayRow) => (
             <div
               key={displayRow}

--- a/src/components/Board/Square.tsx
+++ b/src/components/Board/Square.tsx
@@ -9,8 +9,6 @@ interface SquareProps {
   isCapturable: boolean
   isLastMoveFrom: boolean
   isLastMoveTo: boolean
-  /** 将棋盤の星マーカー（hoshi）を表示するか */
-  isStarPoint?: boolean
   onClick: () => void
 }
 
@@ -21,7 +19,6 @@ export function Square({
   isCapturable,
   isLastMoveFrom,
   isLastMoveTo,
-  isStarPoint = false,
   onClick,
 }: SquareProps) {
   // 木目テクスチャ: 斜めグラデーションで板目を表現
@@ -36,7 +33,7 @@ export function Square({
   else if (isLastMoveTo) bgColor = '#fde047'
   else if (isLastMoveFrom) bgColor = '#fef08a'
 
-  const insetShadow = 'inset 0 0 1px rgba(0,0,0,0.06)'
+  const insetShadow = 'inset 1px 1px 3px rgba(0,0,0,0.15), inset -1px -1px 2px rgba(255,200,80,0.2)'
   const bgStyle = bgColor
     ? { backgroundColor: bgColor, boxShadow: insetShadow }
     : {
@@ -61,14 +58,6 @@ export function Square({
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
           <div className="h-[45%] w-[45%] rounded-full bg-green-600/40" />
         </div>
-      )}
-
-      {/* 星マーカー（hoshi） */}
-      {isStarPoint && !isSelected && !isLegalMove && !isCapturable && (
-        <div
-          className="pointer-events-none absolute rounded-full bg-amber-900/50"
-          style={{ width: 5, height: 5 }}
-        />
       )}
 
       {children}


### PR DESCRIPTION
## Summary

PR #83 マージ後に発覚した不具合を修正。

- 星マーカー（isStarPoint）を削除（不要と判断）
- 段ラベル列の `border-t-2` が盤面右端（1一）からはみ出す問題を修正
- 盤面の `boxShadow` を offset 方式から `inset` 方式に変更（はみ出しなし）
- Square の inset shadow を強化（`rgba(0,0,0,0.06)` → `rgba(0,0,0,0.15)`）して凹み感を視認できるよう改善

## Test plan

- [ ] 盤面右端（1一）に線がはみ出していない
- [x] 星マーカーが表示されない
- [ ] 盤面に立体感・凹み感がある

🤖 Generated with [Claude Code](https://claude.com/claude-code)