### PR TITLE
feat: 手番インジケーターの強化（#75）

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRef, useState, useLayoutEffect } from 'react'
+import { motion } from 'framer-motion'
 import type { AnimatingMoveInfo, Board as BoardType, Move, Player, Position, PromotingInfo } from '@/lib/shogi/types'
 import { Square } from './Square'
 import { Piece } from '@/components/Piece'
@@ -84,8 +85,17 @@ export function Board({
   const lastMoveFrom = lastMove?.type === 'move' ? lastMove.from : null
   const lastMoveTo = lastMove?.to ?? null
 
+  const boardGlow =
+    currentPlayer === 'sente'
+      ? '0 8px 24px rgba(59, 130, 246, 0.5)'
+      : '0 -8px 24px rgba(239, 68, 68, 0.5)'
+
   return (
-    <div className="inline-flex flex-col select-none">
+    <motion.div
+      className="inline-flex flex-col select-none"
+      animate={{ boxShadow: boardGlow }}
+      transition={{ duration: 0.3 }}
+    >
       {/* 筋ラベル（9〜1 または 1〜9） */}
       <div className="flex pr-6">
         {Array.from({ length: 9 }, (_, displayCol) => (
@@ -192,7 +202,7 @@ export function Board({
           ))}
         </div>
       </div>
-    </div>
+    </motion.div>
   )
 }
 

--- a/src/components/Controls/ControlBar.tsx
+++ b/src/components/Controls/ControlBar.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { motion } from 'framer-motion'
 import type { Player } from '@/lib/shogi/types'
 
 interface ControlBarProps {
@@ -26,7 +27,11 @@ export function ControlBar({
   const isSente = currentPlayer === 'sente'
 
   return (
-    <div className="flex h-full w-full items-center justify-between gap-2 px-2">
+    <motion.div
+      className="flex h-full w-full items-center justify-between gap-2 border-l-4 px-2"
+      animate={{ borderColor: isSente ? '#3B82F6' : '#EF4444' }}
+      transition={{ duration: 0.3 }}
+    >
       {/* もどるボタン */}
       <button
         className={[
@@ -45,13 +50,21 @@ export function ControlBar({
       {/* 手番表示 */}
       <div
         className={[
-          'flex flex-1 items-center justify-center rounded-lg px-2 py-1 text-sm font-bold',
+          'flex flex-1 items-center justify-center gap-2 rounded-lg px-2 py-1 text-sm font-bold',
           isSente
             ? 'bg-blue-100 text-blue-900'
             : 'bg-red-100 text-red-900',
         ].join(' ')}
       >
-        あなたのばんだよ！
+        <motion.span
+          className={[
+            'inline-block h-3 w-3 rounded-full',
+            isSente ? 'bg-blue-500' : 'bg-red-500',
+          ].join(' ')}
+          animate={{ scale: [1, 1.4, 1] }}
+          transition={{ duration: 1.2, repeat: Infinity, ease: 'easeInOut' }}
+        />
+        {isSente ? 'あおチームのばん' : 'あかチームのばん'}
       </div>
 
       {/* すすむボタン */}
@@ -86,6 +99,6 @@ export function ControlBar({
       >
         ☰
       </button>
-    </div>
+    </motion.div>
   )
 }


### PR DESCRIPTION
## Summary
- ControlBar に手番色の左ボーダーを追加（Framer Motion で 0.3s クロスフェード）
- 手番表示テキストを「あおチームのばん」/「あかチームのばん」に変更し誰のターンか一目でわかるように
- テキスト横に脈動するドットインジケーターを追加（先手=青 / 後手=赤）
- 盤面外枠に手番色の glow を追加（先手=下辺が青く光る / 後手=上辺が赤く光る）

## Test plan
- [x] 先手番時：ControlBar 左ボーダーが青、ドットが青、テキスト「あおチームのばん」、盤面下辺が青く光る
- [x] 後手番時：ControlBar 左ボーダーが赤、ドットが赤、テキスト「あかチームのばん」、盤面上辺が赤く光る
- [x] 手番切り替え時に 0.3s のクロスフェードが発生する
- [x] ドットが約 1.2s 周期で脈動する

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)