### PR TITLE
feat: UI/UX改善（王手通知動的化・成りダイアログSVG化・視覚一貫性向上）

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -136,12 +136,14 @@ export default function Home() {
       <PromotionDialog
         isOpen={phase === 'promotion_check'}
         pieceType={promotionPieceType}
+        owner={currentPlayer}
         onPromote={promote}
       />
 
       {/* 王手通知バナー */}
       <CheckBanner
         isVisible={phase === 'check_notify'}
+        currentPlayer={currentPlayer}
         onDismiss={completeCheckNotify}
       />
 

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -101,7 +101,7 @@ export function Board({
         {Array.from({ length: 9 }, (_, displayCol) => (
           <div
             key={displayCol}
-            className="flex-1 text-center text-xs font-medium text-amber-900"
+            className="flex-1 text-center text-sm font-medium text-amber-900"
           >
             {colLabel(displayCol)}
           </div>
@@ -113,7 +113,7 @@ export function Board({
         <div className="relative flex-1">
           <div
             ref={gridRef}
-            className="grid grid-cols-9 border-l-2 border-t-2 border-amber-900"
+            className="grid grid-cols-9 border-2 border-amber-900"
             style={{
               boxShadow:
                 'inset 3px 3px 6px rgba(255,210,80,0.35), inset -3px -3px 6px rgba(0,0,0,0.28), 0 4px 16px rgba(0,0,0,0.3)',
@@ -195,7 +195,7 @@ export function Board({
           {Array.from({ length: 9 }, (_, displayRow) => (
             <div
               key={displayRow}
-              className="flex flex-1 items-center justify-center text-xs font-medium text-amber-900"
+              className="flex flex-1 items-center justify-center text-sm font-medium text-amber-900"
             >
               {rowLabel(displayRow)}
             </div>

--- a/src/components/CapturedPieces/CapturedPieces.tsx
+++ b/src/components/CapturedPieces/CapturedPieces.tsx
@@ -58,7 +58,7 @@ export function CapturedPieces({
                 isSelected ? 'ring-2 ring-yellow-400 bg-yellow-50' : '',
                 // 0枚: グレーアウト
                 !hasCount ? 'opacity-30' : '',
-                isClickable ? 'hover:brightness-95' : 'cursor-default',
+                isClickable ? 'hover:brightness-95' : 'cursor-not-allowed',
               ]
                 .filter(Boolean)
                 .join(' ')}

--- a/src/components/Controls/ControlBar.tsx
+++ b/src/components/Controls/ControlBar.tsx
@@ -84,7 +84,12 @@ export function ControlBar({
 
       {/* ミュートボタン */}
       <button
-        className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg bg-stone-200 px-3 text-sm font-bold text-stone-700 hover:bg-stone-300"
+        className={[
+          'flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg px-3 text-sm font-bold transition-colors',
+          isMuted
+            ? 'bg-red-100 text-red-700 hover:bg-red-200'
+            : 'bg-stone-200 text-stone-700 hover:bg-stone-300',
+        ].join(' ')}
         onClick={onToggleMute}
         aria-label={isMuted ? 'ミュート解除' : 'ミュート'}
       >

--- a/src/components/Dialogs/PromotionDialog.tsx
+++ b/src/components/Dialogs/PromotionDialog.tsx
@@ -1,26 +1,30 @@
 'use client'
 
 import { motion, AnimatePresence } from 'framer-motion'
-import type { PieceType } from '@/lib/shogi/types'
+import type { PieceType, Player, PromotedPieceType } from '@/lib/shogi/types'
+import { PIECE_CONFIG } from '@/components/Piece'
+import type { AnimalColors } from '@/components/Piece/animals'
 
 // ============================================================
-// 成り設定（駒種 → メッセージ・絵文字）
+// 成り設定（駒種 → メッセージ・成駒の種類）
 // ============================================================
 
 interface PromotionConfig {
   message: string
-  beforeEmoji: string
-  afterEmoji: string
+  promotedType: PromotedPieceType
 }
 
 const PROMOTION_CONFIG: Partial<Record<PieceType, PromotionConfig>> = {
-  pawn:   { message: 'ひよこがニワトリになれるよ！ なる？', beforeEmoji: '🐤', afterEmoji: '🐔' },
-  lance:  { message: 'イノシシがパワーアップできるよ！ なる？', beforeEmoji: '🐗', afterEmoji: '🐗✨' },
-  knight: { message: 'うさぎがパワーアップできるよ！ なる？', beforeEmoji: '🐰', afterEmoji: '🐰✨' },
-  silver: { message: 'オオカミがパワーアップできるよ！ なる？', beforeEmoji: '🐺', afterEmoji: '🐺✨' },
-  bishop: { message: 'フクロウがパワーアップできるよ！ なる？', beforeEmoji: '🦉', afterEmoji: '🦉✨' },
-  rook:   { message: 'たかがパワーアップできるよ！ なる？',   beforeEmoji: '🦅', afterEmoji: '🦅✨' },
+  pawn:   { message: 'ひよこがニワトリになれるよ！ なる？', promotedType: 'promoted_pawn'   },
+  lance:  { message: 'イノシシがパワーアップできるよ！ なる？', promotedType: 'promoted_lance'  },
+  knight: { message: 'うさぎがパワーアップできるよ！ なる？', promotedType: 'promoted_knight' },
+  silver: { message: 'オオカミがパワーアップできるよ！ なる？', promotedType: 'promoted_silver' },
+  bishop: { message: 'フクロウがパワーアップできるよ！ なる？', promotedType: 'promoted_bishop' },
+  rook:   { message: 'たかがパワーアップできるよ！ なる？',   promotedType: 'promoted_rook'   },
 }
+
+const SENTE_COLORS: AnimalColors = { primary: '#3B82F6', dark: '#1E40AF' }
+const GOTE_COLORS: AnimalColors = { primary: '#EF4444', dark: '#991B1B' }
 
 // ============================================================
 // Props
@@ -29,6 +33,8 @@ const PROMOTION_CONFIG: Partial<Record<PieceType, PromotionConfig>> = {
 interface PromotionDialogProps {
   isOpen: boolean
   pieceType: PieceType | null
+  /** 成りを行うプレイヤー（駒の色を決定） */
+  owner: Player
   onPromote: (doPromote: boolean) => void
 }
 
@@ -36,12 +42,16 @@ interface PromotionDialogProps {
 // コンポーネント
 // ============================================================
 
-export function PromotionDialog({ isOpen, pieceType, onPromote }: PromotionDialogProps) {
+export function PromotionDialog({ isOpen, pieceType, owner, onPromote }: PromotionDialogProps) {
   const config = pieceType ? PROMOTION_CONFIG[pieceType] : null
+  const colors = owner === 'sente' ? SENTE_COLORS : GOTE_COLORS
+
+  const BeforeAnimal = pieceType ? PIECE_CONFIG[pieceType].AnimalComponent : null
+  const AfterAnimal = config ? PIECE_CONFIG[config.promotedType].AnimalComponent : null
 
   return (
     <AnimatePresence>
-      {isOpen && config && (
+      {isOpen && config && BeforeAnimal && AfterAnimal && (
         <>
           {/* 半透明オーバーレイ（タップしても閉じない） */}
           <motion.div
@@ -61,10 +71,14 @@ export function PromotionDialog({ isOpen, pieceType, onPromote }: PromotionDialo
           >
             <div className="w-full max-w-sm rounded-3xl bg-white px-8 py-8 shadow-2xl">
               {/* 変身アニメーション表示 */}
-              <div className="mb-6 flex items-center justify-center gap-4 text-5xl">
-                <span>{config.beforeEmoji}</span>
+              <div className="mb-6 flex items-center justify-center gap-4">
+                <div className="h-16 w-16">
+                  <BeforeAnimal {...colors} isPromoted={false} />
+                </div>
                 <span className="text-2xl text-amber-500">→</span>
-                <span>{config.afterEmoji}</span>
+                <div className="h-16 w-16">
+                  <AfterAnimal {...colors} isPromoted={true} />
+                </div>
               </div>
 
               {/* メッセージ */}
@@ -75,13 +89,13 @@ export function PromotionDialog({ isOpen, pieceType, onPromote }: PromotionDialo
               {/* ボタン */}
               <div className="flex flex-col gap-3">
                 <button
-                  className="min-h-[56px] w-full rounded-2xl bg-amber-500 text-xl font-black text-white shadow-md active:scale-95"
+                  className="min-h-[56px] w-full rounded-2xl bg-blue-500 text-xl font-black text-white shadow-md hover:bg-blue-600 active:scale-95"
                   onClick={() => onPromote(true)}
                 >
                   なる！🌟
                 </button>
                 <button
-                  className="min-h-[48px] w-full rounded-2xl bg-stone-200 text-base font-bold text-stone-600 active:scale-95"
+                  className="min-h-[48px] w-full rounded-2xl bg-stone-200 text-base font-bold text-stone-700 hover:bg-stone-300 active:scale-95"
                   onClick={() => onPromote(false)}
                 >
                   ならない

--- a/src/components/Notifications/CheckBanner.tsx
+++ b/src/components/Notifications/CheckBanner.tsx
@@ -2,19 +2,24 @@
 
 import { useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
+import type { Player } from '@/lib/shogi/types'
 
 interface CheckBannerProps {
   isVisible: boolean
+  /** 王手されているプレイヤー（現在の手番） */
+  currentPlayer: Player
   onDismiss: () => void
 }
 
-export function CheckBanner({ isVisible, onDismiss }: CheckBannerProps) {
+export function CheckBanner({ isVisible, currentPlayer, onDismiss }: CheckBannerProps) {
   // 1.5秒後に自動で閉じる
   useEffect(() => {
     if (!isVisible) return
     const timer = setTimeout(onDismiss, 1500)
     return () => clearTimeout(timer)
   }, [isVisible, onDismiss])
+
+  const teamLabel = currentPlayer === 'sente' ? 'あおチームの' : 'あかチームの'
 
   return (
     <AnimatePresence>
@@ -26,7 +31,7 @@ export function CheckBanner({ isVisible, onDismiss }: CheckBannerProps) {
           exit={{ opacity: 0, y: -20 }}
           transition={{ duration: 0.25 }}
         >
-          🦁💦 ライオンがあぶないよ！
+          🦁💦 {teamLabel}ライオンがあぶないよ！
         </motion.div>
       )}
     </AnimatePresence>


### PR DESCRIPTION
## Summary
- **CheckBanner 動的化**: 後手が王手された場合も「あかチームのライオンがあぶないよ！」と正しく表示（バグ修正相当）
- **PromotionDialog SVG化**: 絵文字から SVG 動物コンポーネントに置換し、駒の見た目と一致させた
- **視覚一貫性向上**: 盤ラベルを text-sm に拡大、盤枠を border-2 に統一、ミュートボタンでミュート状態を色で明示、持ち駒の操作不可時に cursor-not-allowed を追加

## Test plan
- [x] 後手が王手された局面で「あかチームのライオンがあぶないよ！」と表示されることを確認
- [x] 成りダイアログで SVG 動物が before/after 表示されることを確認（先手=青、後手=赤）
- [x] 盤の筋・段ラベルが以前より大きく読みやすいことを確認
- [x] ミュートボタンがミュート時に赤背景になることを確認
- [x] 相手の手番中に持ち駒をホバーすると cursor-not-allowed になることを確認
- [x] `npm run lint && npm run test:run && npm run build` がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)