### PR TITLE
feat: 10秒ヒント（おたすけ機能）の実装（#70）

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { PromotionDialog, ForcedPromotionToast, GameOverDialog, MenuDialog } fro
 import { CheckBanner } from '@/components/Notifications'
 import { TitleScreen } from '@/components/TitleScreen'
 import { useGameStore } from '@/stores/gameStore'
+import { useHintTimer } from '@/hooks/useHintTimer'
 import type { BoardMove, Position, PieceType } from '@/lib/shogi/types'
 import { getPieceAt } from '@/lib/shogi/board'
 
@@ -36,6 +37,9 @@ export default function Home() {
     completeTurnSwitch,
     completeMoveAnimation,
     completePromotion,
+    setHint,
+    clearHint,
+    showHint,
   } = useGameStore()
   const {
     board,
@@ -49,6 +53,15 @@ export default function Home() {
     winner,
     gameOverReason,
   } = gameState
+
+  // ヒントタイマー（10秒/15秒無操作でヒント表示）
+  useHintTimer({
+    phase,
+    isMenuOpen: ui.isMenuOpen,
+    onLevel1: () => setHint(1),
+    onLevel2: () => setHint(2),
+    onClear: clearHint,
+  })
 
   // turn_switching フェーズ完了を自動でトリガー
   // (#19 手番交代アニメーション実装後はアニメーション完了コールバックに置き換える)
@@ -177,6 +190,8 @@ export default function Home() {
           onAnimationComplete={completeMoveAnimation}
           promotingInfo={ui.promotingInfo}
           onPromotionComplete={completePromotion}
+          hintPieces={ui.hintPieces}
+          hintMoves={ui.hintMoves}
         />
 
         {/* 先手の持ち駒エリア（下・固定） */}
@@ -197,10 +212,12 @@ export default function Home() {
             canUndo={canUndo}
             canRedo={canRedo}
             isMuted={ui.isMuted}
+            canShowHint={phase === 'idle' && !ui.isMenuOpen}
             onUndo={undo}
             onRedo={redo}
             onMenu={toggleMenu}
             onToggleMute={toggleMute}
+            onShowHint={showHint}
           />
         </div>
       </div>

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -52,6 +52,8 @@ interface BoardProps {
   onAnimationComplete: () => void
   promotingInfo: PromotingInfo | null
   onPromotionComplete: () => void
+  hintPieces: Position[]
+  hintMoves: Position[]
 }
 
 // ============================================================
@@ -69,6 +71,8 @@ export function Board({
   onAnimationComplete,
   promotingInfo,
   onPromotionComplete,
+  hintPieces,
+  hintMoves,
 }: BoardProps) {
   const gridRef = useRef<HTMLDivElement>(null)
   const [squareSize, setSquareSize] = useState<{ w: number; h: number } | null>(null)
@@ -81,6 +85,8 @@ export function Board({
 
   // Set に変換しておくことでO(1)ルックアップを実現
   const legalMoveSet = new Set(legalMoves.map((p) => `${p.row},${p.col}`))
+  const hintPieceSet = new Set(hintPieces.map((p) => `${p.row},${p.col}`))
+  const hintMoveSet = new Set(hintMoves.map((p) => `${p.row},${p.col}`))
 
   const lastMoveFrom = lastMove?.type === 'move' ? lastMove.from : null
   const lastMoveTo = lastMove?.to ?? null
@@ -138,6 +144,8 @@ export function Board({
               const isLastMoveTo =
                 lastMoveTo?.row === internalPos.row &&
                 lastMoveTo?.col === internalPos.col
+              const isHintPiece = hintPieceSet.has(posKey)
+              const isHintMove = hintMoveSet.has(posKey)
 
               // アニメーション中は移動先マスの駒を非表示（AnimatingPiece が代わりに表示）
               const isAnimatingTarget =
@@ -153,6 +161,8 @@ export function Board({
                   isCapturable={isCapturable}
                   isLastMoveFrom={isLastMoveFrom}
                   isLastMoveTo={isLastMoveTo}
+                  isHintPiece={isHintPiece}
+                  isHintMove={isHintMove}
                   onClick={() => onSquareClick(internalPos)}
                 >
                   {piece && !isAnimatingTarget && (

--- a/src/components/Board/Square.tsx
+++ b/src/components/Board/Square.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { motion } from 'framer-motion'
+
 interface SquareProps {
   /** Piece component を差し込むスロット（#10 で Piece コンポーネントに置き換え） */
   children?: React.ReactNode
@@ -9,6 +11,10 @@ interface SquareProps {
   isCapturable: boolean
   isLastMoveFrom: boolean
   isLastMoveTo: boolean
+  /** ヒント: この駒を動かせる（脈動アニメーション） */
+  isHintPiece: boolean
+  /** ヒント: おすすめの移動先（琥珀色ドット） */
+  isHintMove: boolean
   onClick: () => void
 }
 
@@ -19,6 +25,8 @@ export function Square({
   isCapturable,
   isLastMoveFrom,
   isLastMoveTo,
+  isHintPiece,
+  isHintMove,
   onClick,
 }: SquareProps) {
   // 木目テクスチャ: 斜めグラデーションで板目を表現
@@ -58,6 +66,30 @@ export function Square({
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
           <div className="h-[45%] w-[45%] rounded-full bg-green-600/40" />
         </div>
+      )}
+
+      {/* ヒント: おすすめ移動先ドット（琥珀色・脈動） */}
+      {isHintMove && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <motion.div
+            className="h-[45%] w-[45%] rounded-full bg-amber-400/70"
+            animate={{ scale: [1, 1.25, 1], opacity: [0.7, 1, 0.7] }}
+            transition={{ duration: 1.5, repeat: Infinity, ease: 'easeInOut' }}
+          />
+        </div>
+      )}
+
+      {/* ヒント: 動かせる駒のグロー（黄色・脈動） */}
+      {isHintPiece && (
+        <motion.div
+          className="pointer-events-none absolute inset-0"
+          animate={{ opacity: [0, 0.5, 0] }}
+          transition={{ duration: 1.5, repeat: Infinity, ease: 'easeInOut' }}
+          style={{
+            background:
+              'radial-gradient(circle, rgba(251,191,36,0.7) 30%, transparent 70%)',
+          }}
+        />
       )}
 
       {children}

--- a/src/components/Controls/ControlBar.tsx
+++ b/src/components/Controls/ControlBar.tsx
@@ -8,10 +8,12 @@ interface ControlBarProps {
   canUndo: boolean
   canRedo: boolean
   isMuted: boolean
+  canShowHint: boolean
   onUndo: () => void
   onRedo: () => void
   onMenu: () => void
   onToggleMute: () => void
+  onShowHint: () => void
 }
 
 export function ControlBar({
@@ -19,10 +21,12 @@ export function ControlBar({
   canUndo,
   canRedo,
   isMuted,
+  canShowHint,
   onUndo,
   onRedo,
   onMenu,
   onToggleMute,
+  onShowHint,
 }: ControlBarProps) {
   const isSente = currentPlayer === 'sente'
 
@@ -80,6 +84,21 @@ export function ControlBar({
         aria-label="すすむ"
       >
         すすむ ▶
+      </button>
+
+      {/* おしえてボタン */}
+      <button
+        className={[
+          'flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg px-3 text-sm font-bold transition-colors',
+          canShowHint
+            ? 'bg-amber-100 text-amber-800 hover:bg-amber-200'
+            : 'cursor-not-allowed bg-stone-100 text-stone-400',
+        ].join(' ')}
+        onClick={canShowHint ? onShowHint : undefined}
+        disabled={!canShowHint}
+        aria-label="おしえて"
+      >
+        💡
       </button>
 
       {/* ミュートボタン */}

--- a/src/hooks/useHintTimer.ts
+++ b/src/hooks/useHintTimer.ts
@@ -1,0 +1,60 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import type { GamePhase } from '@/lib/shogi/types'
+
+interface UseHintTimerOptions {
+  phase: GamePhase
+  isMenuOpen: boolean
+  onLevel1: () => void
+  onLevel2: () => void
+  onClear: () => void
+}
+
+/**
+ * 無操作 10秒で level=1（全駒脈動）、15秒で level=2（おすすめ手表示）をトリガーする。
+ * phase が idle 以外になるか isMenuOpen=true になるとタイマーをリセット。
+ */
+export function useHintTimer({
+  phase,
+  isMenuOpen,
+  onLevel1,
+  onLevel2,
+  onClear,
+}: UseHintTimerOptions) {
+  // コールバックを ref で保持してタイマー内での stale closure を防ぐ
+  const onLevel1Ref = useRef(onLevel1)
+  const onLevel2Ref = useRef(onLevel2)
+  const onClearRef = useRef(onClear)
+
+  useEffect(() => {
+    onLevel1Ref.current = onLevel1
+    onLevel2Ref.current = onLevel2
+    onClearRef.current = onClear
+  })
+
+  useEffect(() => {
+    const clearTimers = (timers: ReturnType<typeof setTimeout>[]) => {
+      timers.forEach(clearTimeout)
+    }
+
+    // idle 以外またはメニューオープン中はタイマー停止しヒントをクリア
+    if (phase !== 'idle' || isMenuOpen) {
+      onClearRef.current()
+      return
+    }
+
+    // idle に入ったら 10s / 15s タイマーをセット
+    const t1 = setTimeout(() => {
+      onLevel1Ref.current()
+      const t2 = setTimeout(() => {
+        onLevel2Ref.current()
+      }, 5000) // 10s + 5s = 15s
+      timers.push(t2)
+    }, 10000)
+
+    const timers: ReturnType<typeof setTimeout>[] = [t1]
+
+    return () => clearTimers(timers)
+  }, [phase, isMenuOpen])
+}

--- a/src/lib/shogi/hint.ts
+++ b/src/lib/shogi/hint.ts
@@ -1,0 +1,77 @@
+import type { Board, CapturedPieces, Player, Position } from './types'
+import { getLegalMoves } from './moves'
+import { getPieceAt } from './board'
+
+/**
+ * 現在の手番プレイヤーが動かせる全駒の位置を返す（hintLevel=1 用）
+ */
+export function getMovablePieces(
+  board: Board,
+  capturedPieces: CapturedPieces,
+  currentPlayer: Player,
+): Position[] {
+  const result: Position[] = []
+  for (let row = 0; row < 9; row++) {
+    for (let col = 0; col < 9; col++) {
+      const piece = getPieceAt(board, { row, col })
+      if (!piece || piece.owner !== currentPlayer) continue
+      const moves = getLegalMoves(board, { row, col }, capturedPieces, currentPlayer)
+      if (moves.length > 0) {
+        result.push({ row, col })
+      }
+    }
+  }
+  return result
+}
+
+/**
+ * おすすめ駒と合法手を返す（hintLevel=2 用）
+ * 優先度:
+ *   1. 相手の駒を取れる手を持つ駒
+ *   2. 前方に進める手を持つ駒（先手: row 減少方向、後手: row 増加方向）
+ *   3. 最初に見つかった合法手を持つ駒
+ */
+export function getRecommendedMove(
+  board: Board,
+  capturedPieces: CapturedPieces,
+  currentPlayer: Player,
+): { piece: Position; moves: Position[] } | null {
+  type Candidate = {
+    pos: Position
+    moves: Position[]
+    hasCapture: boolean
+    hasForward: boolean
+  }
+
+  const candidates: Candidate[] = []
+
+  for (let row = 0; row < 9; row++) {
+    for (let col = 0; col < 9; col++) {
+      const piece = getPieceAt(board, { row, col })
+      if (!piece || piece.owner !== currentPlayer) continue
+
+      const moves = getLegalMoves(board, { row, col }, capturedPieces, currentPlayer)
+      if (moves.length === 0) continue
+
+      const hasCapture = moves.some((to) => {
+        const target = getPieceAt(board, to)
+        return target !== null && target.owner !== currentPlayer
+      })
+
+      // 前方: 先手は row が減る方向、後手は row が増える方向
+      const forwardRow = currentPlayer === 'sente' ? row - 1 : row + 1
+      const hasForward = moves.some((to) => to.row === forwardRow)
+
+      candidates.push({ pos: { row, col }, moves, hasCapture, hasForward })
+    }
+  }
+
+  if (candidates.length === 0) return null
+
+  const best =
+    candidates.find((c) => c.hasCapture) ??
+    candidates.find((c) => c.hasForward) ??
+    candidates[0]
+
+  return { piece: best.pos, moves: best.moves }
+}

--- a/src/lib/shogi/types.ts
+++ b/src/lib/shogi/types.ts
@@ -130,6 +130,12 @@ export interface UIState {
   animatingMove: AnimatingMoveInfo | null
   /** 成りアニメーション中の情報（null = アニメーションなし） */
   promotingInfo: PromotingInfo | null
+  /** ヒントレベル（0=なし, 1=脈動のみ, 2=脈動+合法手表示） */
+  hintLevel: 0 | 1 | 2
+  /** ヒント対象の駒の位置（hintLevel>=1 で使用） */
+  hintPieces: Position[]
+  /** おすすめ手の合法手（hintLevel=2 で使用） */
+  hintMoves: Position[]
 }
 
 // ============================================================

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { AnimatingMoveInfo, GameState, PieceType, Player, Position, UIState, PromotingInfo } from '../lib/shogi/types'
 import { getLegalMoves, getLegalDrops, isInCheck } from '../lib/shogi/moves'
+import { getMovablePieces, getRecommendedMove } from '../lib/shogi/hint'
 import { isCheckmate, canPromote, mustPromote } from '../lib/shogi/rules'
 import { executeMove, executeDrop, undoMove, redoMove, createInitialGameState } from '../lib/shogi/game'
 import { getPieceAt } from '../lib/shogi/board'
@@ -47,6 +48,9 @@ interface GameStore {
   clearForcedPromotion: () => void
   completeMoveAnimation: () => void
   completePromotion: () => void
+  setHint: (level: 1 | 2) => void
+  clearHint: () => void
+  showHint: () => void
 }
 
 // ============================================================
@@ -60,6 +64,9 @@ const INITIAL_UI_STATE: UIState = {
   isMuted: false,
   animatingMove: null,
   promotingInfo: null,
+  hintLevel: 0,
+  hintPieces: [],
+  hintMoves: [],
 }
 
 // ============================================================
@@ -547,6 +554,54 @@ export const useGameStore = create<GameStore>()(
             ...state.ui,
             promotingInfo: null,
             ...(isForcedPromote ? { forcedPromotionPiece: pieceType } : {}),
+          },
+        }))
+      },
+
+      // ============================================================
+      // ヒント
+      // ============================================================
+
+      setHint: (level: 1 | 2) => {
+        const { gameState } = get()
+        const { board, capturedPieces, currentPlayer } = gameState
+
+        if (level === 1) {
+          const hintPieces = getMovablePieces(board, capturedPieces, currentPlayer)
+          set(state => ({
+            ui: { ...state.ui, hintLevel: 1, hintPieces, hintMoves: [] },
+          }))
+        } else {
+          const result = getRecommendedMove(board, capturedPieces, currentPlayer)
+          if (!result) return
+          set(state => ({
+            ui: {
+              ...state.ui,
+              hintLevel: 2,
+              hintPieces: [result.piece],
+              hintMoves: result.moves,
+            },
+          }))
+        }
+      },
+
+      clearHint: () => {
+        set(state => ({
+          ui: { ...state.ui, hintLevel: 0, hintPieces: [], hintMoves: [] },
+        }))
+      },
+
+      showHint: () => {
+        const { gameState } = get()
+        const { board, capturedPieces, currentPlayer } = gameState
+        const result = getRecommendedMove(board, capturedPieces, currentPlayer)
+        if (!result) return
+        set(state => ({
+          ui: {
+            ...state.ui,
+            hintLevel: 2,
+            hintPieces: [result.piece],
+            hintMoves: result.moves,
           },
         }))
       },


### PR DESCRIPTION
Closes #70

## Summary
- **10秒無操作**: 動かせる全駒が黄色グローで脈動（hintLevel=1）
- **15秒無操作**: おすすめ1駒＋その合法手を琥珀色ドットで表示（hintLevel=2）
- **「💡おしえて」ボタン**: ControlBar に追加。即座に level=2 のヒントを表示
- phase が idle 以外・メニューオープン・undo/redo でタイマー自動リセット＆ヒントクリア

## 新規ファイル
- `src/lib/shogi/hint.ts` — `getMovablePieces` / `getRecommendedMove` のロジック
- `src/hooks/useHintTimer.ts` — 10s/15s タイマー管理カスタムフック

## Test plan
- [x] 10秒無操作 → 動かせる駒が黄色グローで脈動することを確認
- [x] 15秒無操作 → おすすめ駒1体＋琥珀色合法手ドットが表示されることを確認
- [x] 駒をタップ → ヒント消灯・タイマーリセットを確認
- [x] 「もどる」「すすむ」実行 → ヒント消灯を確認
- [x] メニューを開く → ヒント消灯・タイマー停止を確認
- [x] 「💡おしえて」ボタン → 即座に level=2 表示を確認
- [x] 王手状態では王手解消手のみがヒントに表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)