### PR TITLE
fix: undo/redo 時にヒントをクリアする

### DIFF
--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -402,13 +402,14 @@ export const useGameStore = create<GameStore>()(
         const nextState = undoMove(gameState)
         playSound('undo')
         hapticUndoRedo(get().ui.isMuted)
-        set({
+        set((state) => ({
           gameState: {
             ...nextState,
             phase: 'idle',
             isCheck: false,
           },
-        })
+          ui: { ...state.ui, hintLevel: 0, hintPieces: [], hintMoves: [] },
+        }))
       },
 
       redo: () => {
@@ -421,13 +422,14 @@ export const useGameStore = create<GameStore>()(
         const nextState = redoMove(gameState)
         playSound('redo')
         hapticUndoRedo(get().ui.isMuted)
-        set({
+        set((state) => ({
           gameState: {
             ...nextState,
             phase: 'idle',
             isCheck: false,
           },
-        })
+          ui: { ...state.ui, hintLevel: 0, hintPieces: [], hintMoves: [] },
+        }))
       },
 
       // ============================================================


### PR DESCRIPTION
## Summary
- undo/redo は `phase` が `idle` のまま変化しないため `useHintTimer` が反応せずヒントが消えないバグを修正
- `undo` / `redo` アクション内で直接 `hintLevel=0, hintPieces=[], hintMoves=[]` をリセットする

## Test plan
- [x] ヒント表示中に「もどる」を押すとヒントが消えることを確認
- [x] ヒント表示中に「すすむ」を押すとヒントが消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)