### PR TITLE
feat: 駒の選択/配置の物理演出（#64）

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -85,6 +85,14 @@ export function Board({
 
   // Set に変換しておくことでO(1)ルックアップを実現
   const legalMoveSet = new Set(legalMoves.map((p) => `${p.row},${p.col}`))
+
+  // 着地アニメーションのキー: 手が変わるたびにユニークな文字列を生成
+  // Piece ラッパーの key に使い、isLastMoveTo のマスで Piece を再マウントさせる
+  const lastMoveKey = lastMove
+    ? lastMove.type === 'move'
+      ? `${lastMove.from.row}${lastMove.from.col}-${lastMove.to.row}${lastMove.to.col}`
+      : `drop-${lastMove.to.row}${lastMove.to.col}`
+    : 'init'
   const hintPieceSet = new Set(hintPieces.map((p) => `${p.row},${p.col}`))
   const hintMoveSet = new Set(hintMoves.map((p) => `${p.row},${p.col}`))
 
@@ -166,11 +174,15 @@ export function Board({
                   onClick={() => onSquareClick(internalPos)}
                 >
                   {piece && !isAnimatingTarget && (
-                    <div className="absolute inset-[3px]">
+                    <div
+                      key={isLastMoveTo ? `piece-${posKey}-${lastMoveKey}` : `piece-${posKey}`}
+                      className="absolute inset-[3px]"
+                    >
                       <Piece
                         piece={piece}
                         isSelected={isSelected}
                         isOpponent={piece.owner === 'gote'}
+                        isLanding={isLastMoveTo && !isSelected}
                       />
                     </div>
                   )}

--- a/src/components/Board/Square.tsx
+++ b/src/components/Board/Square.tsx
@@ -52,7 +52,10 @@ export function Square({
 
   return (
     <div
-      className="relative flex aspect-square items-center justify-center border-r border-b border-amber-900/60 cursor-pointer select-none"
+      className={[
+        'relative flex aspect-square items-center justify-center border-r border-b border-amber-900/60 cursor-pointer select-none',
+        isSelected ? 'z-10' : '',
+      ].join(' ')}
       style={bgStyle}
       onClick={onClick}
     >
@@ -89,6 +92,16 @@ export function Square({
             background:
               'radial-gradient(circle, rgba(251,191,36,0.7) 30%, transparent 70%)',
           }}
+        />
+      )}
+
+      {/* 着地フラッシュ（isLastMoveTo マウント時に opacity 0.4→0） */}
+      {isLastMoveTo && (
+        <motion.div
+          className="pointer-events-none absolute inset-0 rounded-sm bg-white"
+          initial={{ opacity: 0.4 }}
+          animate={{ opacity: 0 }}
+          transition={{ duration: 0.3, ease: 'easeOut' }}
         />
       )}
 

--- a/src/components/CapturedPieces/CapturedPieces.tsx
+++ b/src/components/CapturedPieces/CapturedPieces.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { motion } from 'framer-motion'
 import type { CapturedPieces as CapturedPiecesType, PieceType, Player } from '@/lib/shogi/types'
 import { PIECE_CONFIG } from '@/components/Piece'
 import type { AnimalColors } from '@/components/Piece/animals'
@@ -44,9 +45,11 @@ export function CapturedPieces({
         const { AnimalComponent, hiragana } = PIECE_CONFIG[pieceType]
 
         return (
-          <div
+          <motion.div
             key={pieceType}
             className="relative flex h-full max-h-[52px] flex-1 cursor-pointer items-center justify-center"
+            animate={{ scale: isSelected ? 1.12 : 1 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 20 }}
             onClick={() => isClickable && onSelect(pieceType)}
           >
             <div
@@ -77,7 +80,7 @@ export function CapturedPieces({
                 {count}
               </span>
             )}
-          </div>
+          </motion.div>
         )
       })}
     </div>

--- a/src/components/Piece/Piece.tsx
+++ b/src/components/Piece/Piece.tsx
@@ -247,15 +247,17 @@ function useIdleAnimation(
 
 interface PieceProps {
   piece: PieceType
-  /** 選択中: 光彩 + バウンスアニメーション */
+  /** 選択中: scale 拡大 + 影深化 + バウンスアニメーション */
   isSelected?: boolean
   /** 相手の駒: 180度回転表示 */
   isOpponent?: boolean
   /** アイドルアニメーションのスタッガーディレイ（ms）。デフォルト0 */
   idleStaggerDelay?: number
+  /** 配置直後の着地アニメーション（scale 1.08→1.0 スプリングバウンス） */
+  isLanding?: boolean
 }
 
-export function Piece({ piece, isSelected = false, isOpponent = false, idleStaggerDelay = 0 }: PieceProps) {
+export function Piece({ piece, isSelected = false, isOpponent = false, idleStaggerDelay = 0, isLanding = false }: PieceProps) {
   const config = PIECE_CONFIG[piece.type]
   const promoted = isPromotedType(piece.type)
   const isSente = piece.owner === 'sente'
@@ -274,7 +276,7 @@ export function Piece({ piece, isSelected = false, isOpponent = false, idleStagg
       : 'drop-shadow(0 0 1.5px #FCA5A5)'
 
   const filterStyle = isSelected
-    ? `${borderShadow} drop-shadow(0 0 6px rgba(251,191,36,0.95))`
+    ? `${borderShadow} drop-shadow(0 0 6px rgba(251,191,36,0.95)) drop-shadow(0 4px 8px rgba(0,0,0,0.35))`
     : borderShadow
 
   // アイドルアニメーション: 選択中は無効
@@ -292,7 +294,7 @@ export function Piece({ piece, isSelected = false, isOpponent = false, idleStagg
     ? { transform: 'rotate(180deg)', width: '100%', height: '100%' }
     : { width: '100%', height: '100%' }
 
-  // 選択中の場合: 既存のバウンスアニメーション
+  // 選択中: scale 1.12 (spring) + y バウンス (repeat) + 影深化
   if (isSelected) {
     return (
       <div style={opponentRotateStyle}>
@@ -302,8 +304,34 @@ export function Piece({ piece, isSelected = false, isOpponent = false, idleStagg
             clipPath: PIECE_CLIP_PATH,
             filter: filterStyle,
           }}
-          animate={{ y: [0, -4, 0] }}
-          transition={{ duration: 0.5, repeat: Infinity, ease: 'easeInOut' }}
+          initial={{ scale: 1 }}
+          animate={{ scale: 1.12, y: [0, -4, 0] }}
+          transition={{
+            scale: { type: 'spring', stiffness: 400, damping: 20 },
+            y: { duration: 0.5, repeat: Infinity, ease: 'easeInOut', delay: 0.1 },
+          }}
+        >
+          <div className="w-full flex-1 min-h-0 p-0.5">
+            <AnimalComponent {...colors} isPromoted={promoted} />
+          </div>
+          <span className={`text-[8px] font-bold leading-none pb-0.5 ${isSente ? 'text-blue-900' : 'text-red-900'}`}>
+            {hiragana}
+          </span>
+        </motion.div>
+      </div>
+    )
+  }
+
+  // 着地直後: scale 1.08 → 1.0 スプリングバウンス
+  if (isLanding) {
+    return (
+      <div style={opponentRotateStyle}>
+        <motion.div
+          className={`flex h-full w-full flex-col items-center justify-center ${bgClass}`}
+          style={{ clipPath: PIECE_CLIP_PATH, filter: filterStyle }}
+          initial={{ scale: 1.08 }}
+          animate={{ scale: 1.0 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 12 }}
         >
           <div className="w-full flex-1 min-h-0 p-0.5">
             <AnimalComponent {...colors} isPromoted={promoted} />


### PR DESCRIPTION
Closes #64

## Summary
- **選択時（持ち上げ）**: scale 1.12 スプリング拡大 + 影深化（offset-y 4px, blur 8px）+ y バウンス継続
- **z-index**: 選択駒を `z-10` で隣接駒の前面に表示
- **着地時**: `lastMoveKey` を使った Piece 再マウントで scale 1.08→1.0 スプリングバウンスを毎回発火
- **着地フラッシュ**: Square に白 overlay（opacity 0.4→0, 0.3s）を追加
- **持ち駒**: 選択時に scale 1.12 スプリング拡大

## Test plan
- [x] 駒選択 → scale 拡大・影深化・y バウンスを確認
- [x] 選択駒が隣の駒より前面に表示されることを確認
- [x] 駒移動 → 着地マスに白フラッシュ、駒が scale バウンスすることを確認
- [x] 持ち駒選択 → scale 拡大を確認
- [x] 後手の 180 度回転駒でも演出が崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)