### PR TITLE
feat: 合法手ドットの連鎖ポップインアニメーション（#65）

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -37,6 +37,13 @@ function rowLabel(displayRow: number): string {
   return DAN_LABELS[displayRow]
 }
 
+/** チェビシェフ距離ベースのポップイン遅延（ms）を返す */
+function legalMoveInDelay(from: Position | null, to: Position): number {
+  if (!from) return 0
+  const dist = Math.max(Math.abs(to.row - from.row), Math.abs(to.col - from.col))
+  return dist * 40
+}
+
 // ============================================================
 // 型定義
 // ============================================================
@@ -85,6 +92,12 @@ export function Board({
 
   // Set に変換しておくことでO(1)ルックアップを実現
   const legalMoveSet = new Set(legalMoves.map((p) => `${p.row},${p.col}`))
+
+  // ポップアウト逆順のための最大 delay を事前計算
+  const maxLegalDelay =
+    legalMoves.length > 0 && selectedPosition
+      ? Math.max(...legalMoves.map((p) => legalMoveInDelay(selectedPosition, p)))
+      : 0
 
   // 着地アニメーションのキー: 手が変わるたびにユニークな文字列を生成
   // Piece ラッパーの key に使い、isLastMoveTo のマスで Piece を再マウントさせる
@@ -154,6 +167,8 @@ export function Board({
                 lastMoveTo?.col === internalPos.col
               const isHintPiece = hintPieceSet.has(posKey)
               const isHintMove = hintMoveSet.has(posKey)
+              const inDelay = isLegalMove ? legalMoveInDelay(selectedPosition, internalPos) : 0
+              const outDelay = isLegalMove ? maxLegalDelay - inDelay : 0
 
               // アニメーション中は移動先マスの駒を非表示（AnimatingPiece が代わりに表示）
               const isAnimatingTarget =
@@ -171,6 +186,8 @@ export function Board({
                   isLastMoveTo={isLastMoveTo}
                   isHintPiece={isHintPiece}
                   isHintMove={isHintMove}
+                  legalMoveInDelay={inDelay}
+                  legalMoveOutDelay={outDelay}
                   onClick={() => onSquareClick(internalPos)}
                 >
                   {piece && !isAnimatingTarget && (

--- a/src/components/Board/Square.tsx
+++ b/src/components/Board/Square.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 
 interface SquareProps {
   /** Piece component を差し込むスロット（#10 で Piece コンポーネントに置き換え） */
@@ -15,6 +15,10 @@ interface SquareProps {
   isHintPiece: boolean
   /** ヒント: おすすめの移動先（琥珀色ドット） */
   isHintMove: boolean
+  /** 合法手ドットのポップイン遅延（ms）: 駒からのチェビシェフ距離 × 40ms */
+  legalMoveInDelay: number
+  /** 合法手ドットのポップアウト遅延（ms）: 逆順フェードアウト用 */
+  legalMoveOutDelay: number
   onClick: () => void
 }
 
@@ -27,6 +31,8 @@ export function Square({
   isLastMoveTo,
   isHintPiece,
   isHintMove,
+  legalMoveInDelay,
+  legalMoveOutDelay,
   onClick,
 }: SquareProps) {
   // 木目テクスチャ: 斜めグラデーションで板目を表現
@@ -59,17 +65,45 @@ export function Square({
       style={bgStyle}
       onClick={onClick}
     >
-      {/* 取れる駒ハイライト（赤） */}
-      {isCapturable && (
-        <div className="pointer-events-none absolute inset-0 rounded-sm bg-red-400/40" />
-      )}
+      {/* 取れる駒ハイライト（赤・ポップイン + パルス） */}
+      <AnimatePresence>
+        {isCapturable && (
+          <motion.div
+            className="pointer-events-none absolute inset-0 rounded-sm bg-red-400/40"
+            initial={{ scale: 0, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0, opacity: 0, transition: { duration: 0.1, delay: legalMoveOutDelay / 1000 } }}
+            transition={{ type: 'spring', stiffness: 500, damping: 20, delay: legalMoveInDelay / 1000 }}
+          >
+            <motion.div
+              className="absolute inset-0 rounded-sm bg-red-400/30"
+              animate={{ scale: [1, 1.1, 1] }}
+              transition={{ duration: 1.5, repeat: Infinity, ease: 'easeInOut' }}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
 
-      {/* 合法手ドット（緑） */}
-      {isLegalMove && !isCapturable && (
-        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          <div className="h-[45%] w-[45%] rounded-full bg-green-600/40" />
-        </div>
-      )}
+      {/* 合法手ドット（緑・ポップイン） */}
+      <AnimatePresence>
+        {isLegalMove && !isCapturable && (
+          <motion.div
+            className="pointer-events-none absolute inset-0 flex items-center justify-center"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0, transition: { duration: 0.1, delay: legalMoveOutDelay / 1000 } }}
+            transition={{ delay: legalMoveInDelay / 1000 }}
+          >
+            <motion.div
+              className="h-[45%] w-[45%] rounded-full bg-green-600/40"
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              exit={{ scale: 0, transition: { duration: 0.1, delay: legalMoveOutDelay / 1000 } }}
+              transition={{ type: 'spring', stiffness: 500, damping: 20, delay: legalMoveInDelay / 1000 }}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* ヒント: おすすめ移動先ドット（琥珀色・脈動） */}
       {isHintMove && (


### PR DESCRIPTION
Closes #65

## Summary
- **ポップイン**: 合法手ドットが駒からのチェビシェフ距離 × 40ms の stagger でスプリング pop（scale 0→1）
- **ポップアウト**: 選択解除時に逆順（遠い→近い）で 0.1s フェードアウト
- **捕獲可能マス**: ポップイン後に scale 1.0→1.1→1.0 の 1.5s パルスで注目を誘導
- Board.tsx でチェビシェフ距離を計算して `legalMoveInDelay` / `legalMoveOutDelay` を Square に渡す

## Test plan
- [x] 駒選択 → ドットが近い順から順番にポップインすることを目視確認
- [x] 選択解除 → ドットが遠い順にフェードアウトすることを確認
- [x] 別の駒に切り替え → 旧ドット消滅・新ドットポップインがスムーズに遷移することを確認
- [x] 捕獲可能マス → 赤ハイライトがポップイン後にパルスすることを確認
- [x] stagger のテンポが自然か（近接マスは即表示、遠方マスは少し遅れる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)