### PR TITLE
feat: 王手時のキング演出強化（#68）

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,6 +52,7 @@ export default function Home() {
     capturedPieces,
     winner,
     gameOverReason,
+    isCheck,
   } = gameState
 
   // ヒントタイマー（10秒/15秒無操作でヒント表示）
@@ -192,6 +193,7 @@ export default function Home() {
           onPromotionComplete={completePromotion}
           hintPieces={ui.hintPieces}
           hintMoves={ui.hintMoves}
+          isCheck={isCheck}
         />
 
         {/* 先手の持ち駒エリア（下・固定） */}

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -61,6 +61,8 @@ interface BoardProps {
   onPromotionComplete: () => void
   hintPieces: Position[]
   hintMoves: Position[]
+  /** 現在の手番プレイヤーが王手されているか */
+  isCheck: boolean
 }
 
 // ============================================================
@@ -80,6 +82,7 @@ export function Board({
   onPromotionComplete,
   hintPieces,
   hintMoves,
+  isCheck,
 }: BoardProps) {
   const gridRef = useRef<HTMLDivElement>(null)
   const [squareSize, setSquareSize] = useState<{ w: number; h: number } | null>(null)
@@ -92,6 +95,20 @@ export function Board({
 
   // Set に変換しておくことでO(1)ルックアップを実現
   const legalMoveSet = new Set(legalMoves.map((p) => `${p.row},${p.col}`))
+
+  // 王手中の場合、現在手番プレイヤーの王将位置を特定
+  let checkKingPosKey: string | null = null
+  if (isCheck) {
+    outer: for (let r = 0; r < 9; r++) {
+      for (let c = 0; c < 9; c++) {
+        const p = board[r][c]
+        if (p && p.type === 'king' && p.owner === currentPlayer) {
+          checkKingPosKey = `${r},${c}`
+          break outer
+        }
+      }
+    }
+  }
 
   // ポップアウト逆順のための最大 delay を事前計算
   const maxLegalDelay =
@@ -167,6 +184,7 @@ export function Board({
                 lastMoveTo?.col === internalPos.col
               const isHintPiece = hintPieceSet.has(posKey)
               const isHintMove = hintMoveSet.has(posKey)
+              const isKingInCheck = isCheck && checkKingPosKey === posKey
               const inDelay = isLegalMove ? legalMoveInDelay(selectedPosition, internalPos) : 0
               const outDelay = isLegalMove ? maxLegalDelay - inDelay : 0
 
@@ -188,6 +206,7 @@ export function Board({
                   isHintMove={isHintMove}
                   legalMoveInDelay={inDelay}
                   legalMoveOutDelay={outDelay}
+                  isKingInCheck={isKingInCheck}
                   onClick={() => onSquareClick(internalPos)}
                 >
                   {piece && !isAnimatingTarget && (
@@ -200,6 +219,7 @@ export function Board({
                         isSelected={isSelected}
                         isOpponent={piece.owner === 'gote'}
                         isLanding={isLastMoveTo && !isSelected}
+                        isKingInCheck={isKingInCheck}
                       />
                     </div>
                   )}

--- a/src/components/Board/Square.tsx
+++ b/src/components/Board/Square.tsx
@@ -19,6 +19,8 @@ interface SquareProps {
   legalMoveInDelay: number
   /** 合法手ドットのポップアウト遅延（ms）: 逆順フェードアウト用 */
   legalMoveOutDelay: number
+  /** 王手状態の王将がいるマス（赤脈動） */
+  isKingInCheck?: boolean
   onClick: () => void
 }
 
@@ -33,6 +35,7 @@ export function Square({
   isHintMove,
   legalMoveInDelay,
   legalMoveOutDelay,
+  isKingInCheck = false,
   onClick,
 }: SquareProps) {
   // 木目テクスチャ: 斜めグラデーションで板目を表現
@@ -136,6 +139,16 @@ export function Square({
           initial={{ opacity: 0.4 }}
           animate={{ opacity: 0 }}
           transition={{ duration: 0.3, ease: 'easeOut' }}
+        />
+      )}
+
+      {/* 王手: 王将マスの赤脈動 */}
+      {isKingInCheck && (
+        <motion.div
+          className="pointer-events-none absolute inset-0"
+          animate={{ opacity: [0.15, 0.45, 0.15] }}
+          transition={{ duration: 1.5, repeat: Infinity, ease: 'easeInOut' }}
+          style={{ backgroundColor: 'rgba(239,68,68,1)' }}
         />
       )}
 

--- a/src/components/Notifications/CheckBanner.tsx
+++ b/src/components/Notifications/CheckBanner.tsx
@@ -25,13 +25,23 @@ export function CheckBanner({ isVisible, currentPlayer, onDismiss }: CheckBanner
     <AnimatePresence>
       {isVisible && (
         <motion.div
-          className="fixed left-1/2 top-6 z-50 -translate-x-1/2 rounded-2xl bg-red-500 px-6 py-3 text-base font-bold text-white shadow-lg"
+          className="fixed left-1/2 top-6 z-50 -translate-x-1/2 rounded-2xl bg-red-500 px-6 py-3 text-base font-bold text-white shadow-lg flex items-center gap-2"
           initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
+          animate={{ opacity: 1, y: 0, scale: [1, 1.03, 1] }}
           exit={{ opacity: 0, y: -20 }}
-          transition={{ duration: 0.25 }}
+          transition={{
+            opacity: { duration: 0.25 },
+            y: { duration: 0.25 },
+            scale: { duration: 0.5, repeat: Infinity, ease: 'easeInOut', delay: 0.25 },
+          }}
         >
-          🦁💦 {teamLabel}ライオンがあぶないよ！
+          <motion.span
+            animate={{ rotate: [-5, 5, -5, 0] }}
+            transition={{ duration: 0.5, repeat: Infinity, ease: 'easeInOut' }}
+          >
+            🦁
+          </motion.span>
+          <span>💦 {teamLabel}ライオンがあぶないよ！</span>
         </motion.div>
       )}
     </AnimatePresence>

--- a/src/components/Piece/Piece.tsx
+++ b/src/components/Piece/Piece.tsx
@@ -255,9 +255,11 @@ interface PieceProps {
   idleStaggerDelay?: number
   /** 配置直後の着地アニメーション（scale 1.08→1.0 スプリングバウンス） */
   isLanding?: boolean
+  /** 王手状態の王将: ライオンの焦り顔を表示 */
+  isKingInCheck?: boolean
 }
 
-export function Piece({ piece, isSelected = false, isOpponent = false, idleStaggerDelay = 0, isLanding = false }: PieceProps) {
+export function Piece({ piece, isSelected = false, isOpponent = false, idleStaggerDelay = 0, isLanding = false, isKingInCheck = false }: PieceProps) {
   const config = PIECE_CONFIG[piece.type]
   const promoted = isPromotedType(piece.type)
   const isSente = piece.owner === 'sente'
@@ -294,6 +296,8 @@ export function Piece({ piece, isSelected = false, isOpponent = false, idleStagg
     ? { transform: 'rotate(180deg)', width: '100%', height: '100%' }
     : { width: '100%', height: '100%' }
 
+  const animalProps = { ...colors, isPromoted: promoted, isInCheck: piece.type === 'king' ? isKingInCheck : false }
+
   // 選択中: scale 1.12 (spring) + y バウンス (repeat) + 影深化
   if (isSelected) {
     return (
@@ -312,7 +316,7 @@ export function Piece({ piece, isSelected = false, isOpponent = false, idleStagg
           }}
         >
           <div className="w-full flex-1 min-h-0 p-0.5">
-            <AnimalComponent {...colors} isPromoted={promoted} />
+            <AnimalComponent {...animalProps} />
           </div>
           <span className={`text-[8px] font-bold leading-none pb-0.5 ${isSente ? 'text-blue-900' : 'text-red-900'}`}>
             {hiragana}
@@ -334,7 +338,7 @@ export function Piece({ piece, isSelected = false, isOpponent = false, idleStagg
           transition={{ type: 'spring', stiffness: 300, damping: 12 }}
         >
           <div className="w-full flex-1 min-h-0 p-0.5">
-            <AnimalComponent {...colors} isPromoted={promoted} />
+            <AnimalComponent {...animalProps} />
           </div>
           <span className={`text-[8px] font-bold leading-none pb-0.5 ${isSente ? 'text-blue-900' : 'text-red-900'}`}>
             {hiragana}
@@ -360,7 +364,7 @@ export function Piece({ piece, isSelected = false, isOpponent = false, idleStagg
         onAnimationComplete={animState === 'animating' ? onAnimationComplete : undefined}
       >
         <div className="w-full flex-1 min-h-0 p-0.5">
-          <AnimalComponent {...colors} isPromoted={promoted} />
+          <AnimalComponent {...animalProps} />
         </div>
         <span className={`text-[8px] font-bold leading-none pb-0.5 ${isSente ? 'text-blue-900' : 'text-red-900'}`}>
           {hiragana}

--- a/src/components/Piece/animals.tsx
+++ b/src/components/Piece/animals.tsx
@@ -7,6 +7,7 @@ export interface AnimalColors {
 
 interface AnimalProps extends AnimalColors {
   isPromoted?: boolean
+  isInCheck?: boolean
 }
 
 // 成駒バッジ（右上に金色の★）
@@ -22,7 +23,7 @@ function PromotedBadge() {
 }
 
 // ライオン（王将）: アンバーのたてがみ + ブラッシュ + ひげ
-export function Lion({ primary, dark, isPromoted }: AnimalProps) {
+export function Lion({ primary, dark, isPromoted, isInCheck }: AnimalProps) {
   return (
     <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" className="w-full h-full">
       {/* たてがみ（アンバー固定） */}
@@ -32,20 +33,37 @@ export function Lion({ primary, dark, isPromoted }: AnimalProps) {
       {/* 小さな三角耳 */}
       <polygon points="24,34 16,14 36,28" fill={dark} />
       <polygon points="76,34 84,14 64,28" fill={dark} />
-      {/* 目（大きめ） */}
-      <circle cx="37" cy="47" r="11" fill="white" />
-      <circle cx="63" cy="47" r="11" fill="white" />
-      <circle cx="38" cy="48" r="6" fill="#1a1a1a" />
-      <circle cx="64" cy="48" r="6" fill="#1a1a1a" />
-      <circle cx="40" cy="45" r="2.5" fill="white" />
-      <circle cx="66" cy="45" r="2.5" fill="white" />
+      {isInCheck ? (
+        <>
+          {/* 焦り顔: ><目 */}
+          <path d="M28 42 L46 50 M46 42 L28 50" stroke="#1a1a1a" strokeWidth="3.5" strokeLinecap="round" />
+          <path d="M54 42 L72 50 M72 42 L54 50" stroke="#1a1a1a" strokeWidth="3.5" strokeLinecap="round" />
+          {/* 汗マーク（青い水滴） */}
+          <ellipse cx="82" cy="28" rx="5" ry="7" fill="#60A5FA" opacity="0.9" />
+          <polygon points="82,18 78,28 86,28" fill="#60A5FA" opacity="0.9" />
+        </>
+      ) : (
+        <>
+          {/* 通常の目 */}
+          <circle cx="37" cy="47" r="11" fill="white" />
+          <circle cx="63" cy="47" r="11" fill="white" />
+          <circle cx="38" cy="48" r="6" fill="#1a1a1a" />
+          <circle cx="64" cy="48" r="6" fill="#1a1a1a" />
+          <circle cx="40" cy="45" r="2.5" fill="white" />
+          <circle cx="66" cy="45" r="2.5" fill="white" />
+        </>
+      )}
       {/* ブラッシュ（ほっぺのピンク） */}
       <ellipse cx="24" cy="58" rx="10" ry="7" fill="#FFB7C5" opacity="0.8" />
       <ellipse cx="76" cy="58" rx="10" ry="7" fill="#FFB7C5" opacity="0.8" />
       {/* 鼻 */}
       <ellipse cx="50" cy="60" rx="5" ry="3.5" fill={dark} />
-      {/* 笑顔 */}
-      <path d="M43 67 Q50 74 57 67" stroke={dark} strokeWidth="2.5" fill="none" strokeLinecap="round" />
+      {/* 表情: 焦り時は口が逆三角（焦り）、通常は笑顔 */}
+      {isInCheck ? (
+        <path d="M43 72 Q50 65 57 72" stroke={dark} strokeWidth="2.5" fill="none" strokeLinecap="round" />
+      ) : (
+        <path d="M43 67 Q50 74 57 67" stroke={dark} strokeWidth="2.5" fill="none" strokeLinecap="round" />
+      )}
       {/* ひげ */}
       <line x1="8" y1="58" x2="40" y2="61" stroke={dark} strokeWidth="1.5" strokeLinecap="round" opacity="0.6" />
       <line x1="8" y1="65" x2="40" y2="65" stroke={dark} strokeWidth="1.5" strokeLinecap="round" opacity="0.6" />


### PR DESCRIPTION
## Summary
- 王手中の王将マスが赤く脈動（opacity 0.15↔0.45, 1.5s周期）
- ライオンが焦り顔に変化（><目、汗マーク、逆口）、王手解消で通常顔に戻る
- CheckBanner にスケールパルス（1→1.03→1）とライオンアイコンの左右揺れを追加

## Test plan
- [x] 王手局面を手動作成し、王将マスが赤く脈動することを確認
- [x] ライオン駒が焦り顔（><目 + 汗マーク）に変わることを確認
- [x] 王手解消後（移動/合駒/打ち）で通常顔・脈動消滅を確認
- [x] CheckBanner のパルスアニメーションとライオン揺れを確認
- [x] `npm run lint && npm run test:run && npm run build` がすべて通ること

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)