### PR TITLE
fix: 後手の持ち駒バッジを180度回転＋位置反転

### DIFF
--- a/src/components/CapturedPieces/CapturedPieces.tsx
+++ b/src/components/CapturedPieces/CapturedPieces.tsx
@@ -75,9 +75,14 @@ export function CapturedPieces({
               </div>
             </div>
 
-            {/* 枚数バッジ */}
+            {/* 枚数バッジ（後手は180度回転＋位置反転） */}
             {hasCount && (
-              <span className="absolute -right-0.5 -top-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-amber-700 text-[9px] font-bold text-white">
+              <span
+                className={`absolute flex h-4 w-4 items-center justify-center rounded-full bg-amber-700 text-[9px] font-bold text-white ${
+                  isSente ? '-right-0.5 -top-0.5' : '-bottom-0.5 -left-0.5'
+                }`}
+                style={isSente ? undefined : { transform: 'rotate(180deg)' }}
+              >
                 {count}
               </span>
             )}


### PR DESCRIPTION
## Summary
- 後手の持ち駒エリアの枚数バッジが回転されておらず、後手プレイヤーから見ると数字が逆さまだった
- バッジに `rotate(180deg)` を適用し、位置を `-bottom-0.5 -left-0.5` に反転

Closes #145

## Test plan
- [x] lint / test(405) / build 全てPASS
- [x] 後手の持ち駒バッジが後手プレイヤー視点で正しく読めること
- [ ] 先手の持ち駒バッジが従来通り正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)